### PR TITLE
EIP1-1934 - Configured spring security

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,6 +65,10 @@ dependencies {
     implementation("org.springframework:spring-webflux")
     implementation("io.projectreactor.netty:reactor-netty-http")
 
+    // spring security
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
+
     implementation("io.awspring.cloud:spring-cloud-starter-aws-messaging")
 
     // AWS dependencies (that are defined in the BOM io.awspring.cloud:spring-cloud-aws-dependencies)

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/config/CognitoJwtAuthenticationConverter.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/config/CognitoJwtAuthenticationConverter.kt
@@ -1,0 +1,43 @@
+package uk.gov.dluhc.notificationsapi.config
+
+import org.springframework.core.convert.converter.Converter
+import org.springframework.security.authentication.AbstractAuthenticationToken
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+import org.springframework.stereotype.Component
+
+/**
+ * Custom JWT Converter implementation that returns a Spring Security Authentication Token based on the claims within
+ * the Cognito JWT.
+ *
+ * Specifically this pulls the group names from the claim `cognito:groups` and uses them as the Authentication authorities
+ * so that Spring Security can recognise the group/role membership via `@PreAuthorise('hasRole=....')`
+ *
+ * It also sets the principal name from the JWT email (the user's cognito username, which is their email address)
+ * rather than the JWT subject (which is a cognito internal ID)
+ */
+@Component
+class CognitoJwtAuthenticationConverter : Converter<Jwt, AbstractAuthenticationToken> {
+
+    override fun convert(jwt: Jwt): AbstractAuthenticationToken {
+        val authorities: List<GrantedAuthority> = jwt.claims["cognito:groups"]?.let {
+            it as Collection<*>
+        }?.map {
+            SimpleGrantedAuthority(it.toString())
+        } ?: emptyList()
+        return JwtAuthenticationToken(jwt, authorities, jwt.email)
+    }
+
+    /**
+     * Return the user's email address from the JWT.
+     * In production (real AWS Cognito), the JWT has a claim called `email`
+     * For our integration tests (that use this class) we use localstack. Localstack's cognito implementation does not appear
+     * to strictly follow AWS' and does not have an `email` claim, and instead has a `username` claim (which AWS' doesn't !)
+     */
+    private val Jwt.email: String
+        get() = claims["email"]?.toString()
+            ?: claims["username"]?.toString()
+            ?: throw IllegalStateException("Email claim not found in JWT")
+}

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/config/SecurityConfiguration.kt
@@ -1,0 +1,110 @@
+package uk.gov.dluhc.notificationsapi.config
+
+import com.nimbusds.jose.PlainHeader
+import com.nimbusds.jose.proc.BadJOSEException
+import com.nimbusds.jose.proc.SecurityContext
+import com.nimbusds.jwt.JWT
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.PlainJWT
+import com.nimbusds.jwt.SignedJWT
+import com.nimbusds.jwt.proc.BadJWTException
+import com.nimbusds.jwt.proc.DefaultJWTProcessor
+import org.springframework.context.annotation.Bean
+import org.springframework.http.HttpMethod.OPTIONS
+import org.springframework.http.HttpStatus.FORBIDDEN
+import org.springframework.http.HttpStatus.UNAUTHORIZED
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
+import org.springframework.security.web.SecurityFilterChain
+import java.text.ParseException
+
+@EnableWebSecurity
+@EnableMethodSecurity
+class SecurityConfiguration(
+    private val cognitoJwtAuthenticationConverter: CognitoJwtAuthenticationConverter
+) {
+
+    @Bean
+    fun filterChain(http: HttpSecurity): SecurityFilterChain =
+        http.also { httpSecurity ->
+            httpSecurity
+                .sessionManagement {
+                    it.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                }
+                .exceptionHandling {
+                    it.authenticationEntryPoint { _, response, _ ->
+                        response.status = UNAUTHORIZED.value()
+                    }
+                    it.accessDeniedHandler { _, response, _ ->
+                        response.status = FORBIDDEN.value()
+                    }
+                }
+                .cors { }
+                .formLogin { it.disable() }
+                .httpBasic { it.disable() }
+                .authorizeRequests {
+                    it.antMatchers(OPTIONS).permitAll()
+                    it.antMatchers("/actuator/**").permitAll()
+                    it.anyRequest().authenticated()
+                }
+                .oauth2ResourceServer { oAuth2ResourceServerConfigurer ->
+                    oAuth2ResourceServerConfigurer.jwt {
+                        it.jwtAuthenticationConverter(cognitoJwtAuthenticationConverter)
+                        it.decoder(NimbusJwtDecoder(SignatureNonValidatingJWTProcessor()))
+                    }
+                }
+        }.build()
+}
+
+/**
+ * Subclass of [DefaultJWTProcessor] to change the behaviour regarding signed JWTs.
+ *
+ * Signed JWTs are converted into plain JWTs (no signature) so that the JWT Processor
+ * does not try to validate the signature or verify the claims against the signature.
+ *
+ * The method to process plain JWTs is implemented, as it is left unimplemented in the
+ * [DefaultJWTProcessor].
+ *
+ * This change of behaviour is deliberate and by design. Access Token JWTs are issued to
+ * the UI by Cognito. The UI presents the JWT to the REST APIs via API Gateway. API Gateway
+ * validates the signature and verifies the claims before forwarding the request to the
+ * microservice. Therefore the bearer token (JWT) presented to the APIs of this microservice
+ * can be considered trusted, and the default behaviour of validating the signature and
+ * verifying the claims is an inefficiency.
+ *
+ * This approach relies on the network security in respect of VPC and Security Group configuration
+ * and does not protect against a man-in-the middle attack (assuming traffic between API Gateway and
+ * this microservice could be intercepted and manipulated)
+ */
+class SignatureNonValidatingJWTProcessor : DefaultJWTProcessor<SecurityContext>() {
+
+    override fun process(jwt: JWT, context: SecurityContext?): JWTClaimsSet =
+        super.process(jwt.convertSignedJwtToPlainJwt(), context)
+
+    override fun process(plainJWT: PlainJWT, context: SecurityContext?): JWTClaimsSet {
+        if (jwsTypeVerifier == null) {
+            throw BadJOSEException("Plain JWT rejected: No JWS header typ (type) verifier is configured")
+        }
+        jwsTypeVerifier.verify(plainJWT.header.type, context)
+
+        return extractJWTClaimsSet(plainJWT)
+    }
+
+    private fun extractJWTClaimsSet(jwt: JWT): JWTClaimsSet =
+        try {
+            jwt.jwtClaimsSet
+        } catch (e: ParseException) {
+            // Payload not a JSON object
+            throw BadJWTException(e.message, e)
+        }
+
+    private fun JWT.convertSignedJwtToPlainJwt(): JWT =
+        if (this is SignedJWT) {
+            PlainJWT(PlainHeader(), this.jwtClaimsSet)
+        } else {
+            this
+        }
+}

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/rest/SecurityController.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/rest/SecurityController.kt
@@ -1,0 +1,23 @@
+package uk.gov.dluhc.notificationsapi.rest
+
+import org.springframework.http.HttpStatus
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * Simple controller to allow tests of spring security whilst we dont have other controllers
+ * TODO - delete this controller and associated tests when we implement controllers to support stories
+ */
+@RestController
+class SecurityController {
+
+    @GetMapping("/secured-endpoint")
+    @ResponseStatus(HttpStatus.OK)
+    @PreAuthorize("isAuthenticated()")
+    fun securedEndpoint(authentication: Authentication): String {
+        return "Hello ${authentication.name}"
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/SecurityControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/SecurityControllerIntegrationTest.kt
@@ -1,0 +1,46 @@
+package uk.gov.dluhc.notificationsapi.rest
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.dluhc.notificationsapi.config.IntegrationTest
+import uk.gov.dluhc.notificationsapi.testsupport.bearerToken
+
+// TODO - delete this test when we implement controllers and their tests for stories
+internal class SecurityControllerIntegrationTest : IntegrationTest() {
+
+    companion object {
+        private const val BEARER_TOKEN: String =
+            "Bearer eyJraWQiOiIvd1Jvb2Q3Y29GODVvLzVNbldDWlBDM1BkOFBWRDZGaFQ2QlZDWGdTL1AwPSIsImFsZyI6IlJTMjU2In0.eyJhdF9oYXNoIjoiUTVHRUFEcWNoR3RlZ1g5MDRQS0UyQSIsInN1YiI6IjVhMTAwMTk4LWRmNWItNDBmZS1hMjIwLTRhMzJiNmNlMGY3YSIsImNvZ25pdG86Z3JvdXBzIjpbImVyby12Yy1hZG1pbi1jYW1kZW4tbG9uZG9uLWJvcm91Z2gtY291bmNpbCIsImVyby1jYW1kZW4tbG9uZG9uLWJvcm91Z2gtY291bmNpbCIsImVyby1hZG1pbi1jYW1kZW4tbG9uZG9uLWJvcm91Z2gtY291bmNpbCJdLCJpc3MiOiJodHRwczovL2NvZ25pdG8taWRwLmV1LXdlc3QtMi5hbWF6b25hd3MuY29tL2V1LXdlc3QtMl8xMjN0NXhBYmMiLCJjb2duaXRvOnVzZXJuYW1lIjoiMmMzMmZiNGItNzMxOC00ZWE5LWI4YzctNjIxMjQ3NDFjNzhkIiwib3JpZ2luX2p0aSI6IjllOTljNDlhLThhZDUtNGQ3Yy05Y2UxLTEzZDYyYzIzOGFiYiIsImF1ZCI6IjJsc2kzcDQ2YXBuaDRlMjBlOHQybHRkbXQ5IiwiZXZlbnRfaWQiOiI0NjQ4ZmRlMC04NWViLTRhY2ItOWZhOC02NjA5ZWY2NDUxZGIiLCJ0b2tlbl91c2UiOiJpZCIsImF1dGhfdGltZSI6MTY2MTg1MjcwMSwicGhvbmVfbnVtYmVyIjoiKzQ0Nzg5MDc2NTQxMSIsImlhdCI6MTY2MTg1MjczNCwianRpIjoiMjI3Y2FmNGEtMjFjOS00NTI4LThkZDctYmE4Y2UwYzY5YTQ0IiwiZW1haWwiOiJhbi1lcm8tdXNlckBhLWNvdW5jaWwuZ292LnVrIn0.Ne-QycvW9kElO7SDG5Wxa7BtXG9qkE1Nld60f6urvm8u_G17CXQofjePdIR4Gkkjrog8OL4zCzzTMh7rqzLPsrYZE7CCpFdr7Wki56RbQ1uh_rYxgqVMMntwfxZvpsQU3WXJTR5IUTOCr4_iw8KWV8rCMb2yIEn7SXGMZt_J1sY"
+    }
+
+    @Test
+    fun `should return principal name given request with bearer token`() {
+        // Given
+        val request = webTestClient.get()
+            .uri("/secured-endpoint")
+            .bearerToken(BEARER_TOKEN)
+
+        // When
+        val response = request.exchange()
+
+        // Then
+        val responseBody = response
+            .expectStatus().isOk
+            .expectBody(String::class.java)
+            .returnResult()
+            .responseBody
+        assertThat(responseBody).isEqualTo("Hello an-ero-user@a-council.gov.uk")
+    }
+
+    @Test
+    fun `should return unauthorized given no bearer token`() {
+        // Given
+        val request = webTestClient.get().uri("/secured-endpoint")
+
+        // When
+        val response = request.exchange()
+
+        // Then
+        response.expectStatus().isUnauthorized
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/WebTestClientExtensions.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/WebTestClientExtensions.kt
@@ -1,0 +1,6 @@
+package uk.gov.dluhc.notificationsapi.testsupport
+
+import org.springframework.test.web.reactive.server.WebTestClient
+
+fun WebTestClient.RequestHeadersSpec<*>.bearerToken(bearerToken: String): WebTestClient.RequestBodySpec =
+    header("authorization", bearerToken) as WebTestClient.RequestBodySpec


### PR DESCRIPTION
This PR adds spring security to `notifications-api` with a basic controller and test to prove (both to be deleted when we implement a real controller)

There is a difference in design in this PR compared to our other apps such as VCA that I would like to draw people's attention to and get your thoughts on ....

For a while @Neil-Massey and I have been thinking the current process is slightly inefficient. The current process is:

1. The UI authenticates with Cognito directly and obtains an access token
2. The UI presents the access token (bearer token in `authorization` header in all API requests
3. API Gateway receives the request 
4. API Gateway authorizes the request via it's Cognito authorizer. 
It validates the signature of the JWT, not the claims (group memberships). 
IE. it doesnt authorize in respect of group/role membership. It verifies the signature which has the effect of confirming the access token was issued by the correct cognito user pool
5. API Gateway forwards the request. complete with the `authorization` header to the relevant Spring Boot app
6. Spring Security in the Spring Boot app (re) validates the signature of the access token with the cognito user pool
IE. it makes a request to Cognito to get the JWKS to validate the signature with
7. The rest of Spring Security does it stuff by extracting the `cognito:groups` claim and creating an authentication token etc.

Neil and I have been thinking step 6 above is potentially an inefficiency and whether it can be skipped. The signature would have still have been validated by API Gateway in step 4, and the Spring Boot app would in essence be implicitly trusting the access token presented.

Thats the difference in this PR that I'd like some thoughts on .... though interestingly I might have answered some of my own questions when I wrote the javadoc for class `SignatureNonValidatingJWTProcessor`

Not only are my javadoc comments making me question it, but also the difficulty in doing this. It was not easy code to work out and write!
We've all been working with Spring for a long time. As a general rule I think they make things easy to do if they are good ideas. If something is really hard to do, there's little documentation/examples on how to do it, and you end up writing code (rather than setting a few properties etc) it feels like Spring have not made it easy to do .... and I wonder if that means its a bad idea?

What do we think? Is this a bad idea?
 
@Neil-Massey, @stalwartsolutions - I would be particularly interested in your thoughts given your knowledge of how our AWS infra is designed (VPCs, SGs etc) - as per my javadoc on `SignatureNonValidatingJWTProcessor` could we in theory be at risk of a man-in-the-middle attack? 