### PR TITLE
EIP1-1934 - Added GlobalExceptionHandler with support for returning a response body

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -138,6 +138,7 @@ tasks.create("generate-models-from-openapi-document-NotificationsAPIs.yaml", Gen
     enabled = true
     inputSpec.set("$projectDir/src/main/resources/openapi/NotificationsAPIs.yaml")
     packageName.set("uk.gov.dluhc.notificationsapi")
+    configOptions.put("documentationProvider", "none")
 }
 
 // Add the generated code to the source sets

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/config/ErrorAttributesConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/config/ErrorAttributesConfiguration.kt
@@ -1,0 +1,64 @@
+package uk.gov.dluhc.notificationsapi.config
+
+import org.springframework.boot.web.error.ErrorAttributeOptions
+import org.springframework.boot.web.error.ErrorAttributeOptions.Include
+import org.springframework.boot.web.servlet.error.DefaultErrorAttributes
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.validation.FieldError
+import org.springframework.web.context.request.WebRequest
+import uk.gov.dluhc.notificationsapi.models.ErrorResponse
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.Date
+
+@Configuration
+class ErrorAttributesConfiguration {
+
+    @Bean
+    fun apiRequestErrorAttributes() = ApiRequestErrorAttributes()
+}
+
+class ApiRequestErrorAttributes : DefaultErrorAttributes() {
+
+    companion object {
+        private const val TIMESTAMP = "timestamp"
+        private const val STATUS = "status"
+        private const val ERROR = "error"
+        private const val MESSAGE = "message"
+        private const val ERRORS = "errors"
+
+        private val errorAttributeOptions = ErrorAttributeOptions.defaults()
+            .including(Include.MESSAGE, Include.BINDING_ERRORS)
+    }
+
+    fun getErrorResponse(request: WebRequest): ErrorResponse =
+        getErrorAttributes(request, errorAttributeOptions).let {
+            ErrorResponse(
+                timestamp = it.getTimeStamp(),
+                status = it.getStatus(),
+                error = it.getError(),
+                message = it.getMessage(),
+                validationErrors = it.getErrors()
+            )
+        }
+
+    private fun Map<String, Any>.getTimeStamp(): OffsetDateTime =
+        (this[TIMESTAMP] as Date).toInstant().atOffset(ZoneOffset.UTC)
+
+    private fun Map<String, Any>.getStatus(): Int =
+        this[STATUS] as Int
+
+    private fun Map<String, Any>.getError(): String =
+        this[ERROR].toString()
+
+    private fun Map<String, Any>.getMessage(): String =
+        this[MESSAGE].toString()
+
+    private fun Map<String, Any>.getErrors(): List<String>? =
+        (this[ERRORS] as List<*>?)
+            ?.map { it as FieldError }
+            ?.map {
+                "Error on field '${it.field}': rejected value [${it.rejectedValue}], ${it.defaultMessage}"
+            }
+}

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/rest/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/rest/GlobalExceptionHandler.kt
@@ -1,0 +1,43 @@
+package uk.gov.dluhc.notificationsapi.rest
+
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST
+import org.springframework.web.context.request.WebRequest
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
+import uk.gov.dluhc.notificationsapi.config.ApiRequestErrorAttributes
+import javax.servlet.RequestDispatcher.ERROR_STATUS_CODE
+
+@ControllerAdvice
+class GlobalExceptionHandler(
+    private var errorAttributes: ApiRequestErrorAttributes
+) : ResponseEntityExceptionHandler() {
+
+    override fun handleHttpMessageNotReadable(
+        e: HttpMessageNotReadableException,
+        headers: HttpHeaders,
+        status: HttpStatus,
+        request: WebRequest
+    ): ResponseEntity<Any> {
+        request.setAttribute(ERROR_STATUS_CODE, status.value(), SCOPE_REQUEST)
+        val body = errorAttributes.getErrorResponse(request)
+
+        return handleExceptionInternal(e, body, headers, status, request)
+    }
+
+    override fun handleMethodArgumentNotValid(
+        e: MethodArgumentNotValidException,
+        headers: HttpHeaders,
+        status: HttpStatus,
+        request: WebRequest
+    ): ResponseEntity<Any> {
+        request.setAttribute(ERROR_STATUS_CODE, status.value(), SCOPE_REQUEST)
+        val body = errorAttributes.getErrorResponse(request)
+
+        return handleExceptionInternal(e, body, headers, status, request)
+    }
+}

--- a/src/main/resources/openapi/NotificationsAPIs.yaml
+++ b/src/main/resources/openapi/NotificationsAPIs.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
-  title: Notificagtions APIs
-  version: '1.0'
+  title: Notifications APIs
+  version: '1.0.0'
   description: Notifications APIs
   contact:
     name: Krister Bone
@@ -45,6 +45,49 @@ paths:
         httpMethod: GET
 
 components:
+  #
+  # Schema and Enum Definitions
+  # --------------------------------------------------------------------------------
+  schemas:
+    ErrorResponse:
+      title: ErrorResponse
+      description: Response describing errors in a web request
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+          example: '2022-09-28T18:01:42.105Z'
+        status:
+          type: integer
+          example: 400
+        error:
+          type: string
+          example: 'Bad Request'
+        message:
+          type: string
+          example: 'Validation failed for object=''registerCheckResultRequest''. Error count: 1'
+        validationErrors:
+          type: array
+          items:
+            type: string
+          example:
+            - 'Error on field ''gssCode'': rejected value [1234], must match "^[a-zA-Z]\d{8}$"'
+      required:
+        - timestamp
+        - status
+        - error
+        - message
+
+  #
+  # Response Body Definitions
+  # --------------------------------------------------------------------------------
+  responses: { }
+
+  #
+  # Request Body Definitions
+  # --------------------------------------------------------------------------------
+  requestBodies: { }
+
   securitySchemes:
     eroUserCognitoUserPoolAuthorizer:
       type: apiKey

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/config/ApiRequestErrorAttributesTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/config/ApiRequestErrorAttributesTest.kt
@@ -1,0 +1,81 @@
+package uk.gov.dluhc.notificationsapi.config
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus.BAD_REQUEST
+import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.validation.BindException
+import org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST
+import org.springframework.web.context.request.ServletWebRequest
+import uk.gov.dluhc.notificationsapi.testsupport.model.ErrorResponseAssert.Companion.assertThat
+import java.time.OffsetDateTime
+import java.time.temporal.ChronoUnit
+import javax.servlet.RequestDispatcher
+import javax.validation.constraints.Size
+
+internal class ApiRequestErrorAttributesTest {
+
+    private lateinit var apiRequestErrorAttributes: ApiRequestErrorAttributes
+
+    @BeforeEach
+    fun setup() {
+        apiRequestErrorAttributes = ApiRequestErrorAttributes()
+    }
+
+    @Test
+    fun `should get error response given a non-binding result exception`() {
+        // Given
+        val exception = IllegalStateException("Some unknown state")
+
+        val httpRequest = MockHttpServletRequest()
+        val webRequest = ServletWebRequest(httpRequest).apply {
+            setAttribute(RequestDispatcher.ERROR_EXCEPTION, exception, SCOPE_REQUEST)
+            setAttribute(RequestDispatcher.ERROR_STATUS_CODE, INTERNAL_SERVER_ERROR.value(), SCOPE_REQUEST)
+        }
+
+        val earliestExpectedTimeStamp = OffsetDateTime.now().truncatedTo(ChronoUnit.MILLIS)
+
+        // When
+        val actual = apiRequestErrorAttributes.getErrorResponse(webRequest)
+
+        // Then
+        assertThat(actual)
+            .hasTimestampNotBefore(earliestExpectedTimeStamp)
+            .hasStatus(500)
+            .hasError("Internal Server Error")
+            .hasMessage("Some unknown state")
+            .hasNoValidationErrors()
+    }
+
+    @Test
+    fun `should get error response given a binding result exception`() {
+        // Given
+        val exception = BindException(TestBean("a"), "testBean")
+        exception.rejectValue("aField", "errorCode", "should be greater than 2 chars in length")
+
+        val httpRequest = MockHttpServletRequest()
+        val webRequest = ServletWebRequest(httpRequest).apply {
+            setAttribute(RequestDispatcher.ERROR_EXCEPTION, exception, SCOPE_REQUEST)
+            setAttribute(RequestDispatcher.ERROR_STATUS_CODE, BAD_REQUEST.value(), SCOPE_REQUEST)
+        }
+
+        val earliestExpectedTimeStamp = OffsetDateTime.now().truncatedTo(ChronoUnit.MILLIS)
+
+        // When
+        val actual = apiRequestErrorAttributes.getErrorResponse(webRequest)
+
+        // Then
+        assertThat(actual)
+            .hasTimestampNotBefore(earliestExpectedTimeStamp)
+            .hasStatus(400)
+            .hasError("Bad Request")
+            .hasMessage("Validation failed for object='testBean'. Error count: 1")
+            .hasValidationError("Error on field 'aField': rejected value [a], should be greater than 2 chars in length")
+    }
+}
+
+data class TestBean(
+    @Size(min = 2)
+    val aField: String
+)

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/model/ErrorResponseAssert.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/model/ErrorResponseAssert.kt
@@ -1,0 +1,83 @@
+package uk.gov.dluhc.notificationsapi.testsupport.model
+
+import org.assertj.core.api.AbstractAssert
+import uk.gov.dluhc.notificationsapi.models.ErrorResponse
+import java.time.OffsetDateTime
+
+class ErrorResponseAssert(actual: ErrorResponse?) :
+    AbstractAssert<ErrorResponseAssert, ErrorResponse?>(actual, ErrorResponseAssert::class.java) {
+
+    companion object {
+        fun assertThat(actual: ErrorResponse?) = ErrorResponseAssert(actual)
+    }
+
+    fun hasTimestampNotBefore(expected: OffsetDateTime): ErrorResponseAssert {
+        isNotNull
+        with(actual!!) {
+            if (timestamp.isBefore(expected)) {
+                failWithMessage("Expected timestamp to not be before $expected, but was $timestamp")
+            }
+        }
+        return this
+    }
+
+    fun hasStatus(expected: Int): ErrorResponseAssert {
+        isNotNull
+        with(actual!!) {
+            if (status != expected) {
+                failWithMessage("Expected status $expected, but was $status")
+            }
+        }
+        return this
+    }
+
+    fun hasError(expected: String): ErrorResponseAssert {
+        isNotNull
+        with(actual!!) {
+            if (error != expected) {
+                failWithMessage("Expected error $expected, but was $error")
+            }
+        }
+        return this
+    }
+
+    fun hasMessage(expected: String): ErrorResponseAssert {
+        isNotNull
+        with(actual!!) {
+            if (message != expected) {
+                failWithMessage("Expected message $expected, but was $message")
+            }
+        }
+        return this
+    }
+
+    fun hasMessageContaining(expected: String): ErrorResponseAssert {
+        isNotNull
+        with(actual!!) {
+            if (!message.contains(expected)) {
+                failWithMessage("Expected message to contain $expected, but was $message")
+            }
+        }
+        return this
+    }
+
+    fun hasValidationError(expected: String): ErrorResponseAssert {
+        isNotNull
+        with(actual!!) {
+            if (validationErrors?.any { it == expected } != true) {
+                failWithMessage("Expected a validation message $expected, but was $validationErrors")
+            }
+        }
+        return this
+    }
+
+    fun hasNoValidationErrors(): ErrorResponseAssert {
+        isNotNull
+        with(actual!!) {
+            if (validationErrors != null) {
+                failWithMessage("Expected no validation messages, but was $validationErrors")
+            }
+        }
+        return this
+    }
+}


### PR DESCRIPTION
This PR adds `GlobalExceptionHandler` with support for returning a response body, in exactly the same way that we have with RCA (I copied it from there 😁 )