### PR TITLE
EIP1-1934: EIP1-2010: Implement generateTemplatePreview for GovNotifyApiClient

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/client/GovNotifyApiClient.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/client/GovNotifyApiClient.kt
@@ -2,6 +2,7 @@ package uk.gov.dluhc.notificationsapi.client
 
 import mu.KotlinLogging
 import org.springframework.stereotype.Component
+import uk.gov.dluhc.notificationsapi.dto.api.NotifyTemplatePreviewDto
 import uk.gov.service.notify.NotificationClient
 
 private val logger = KotlinLogging.logger {}
@@ -16,4 +17,9 @@ class GovNotifyApiClient(private val notificationClient: NotificationClient) {
         val sendEmailResponse = notificationClient.sendEmail("templateId", "emailAddress", null, "reference")
         logger.info { "Email response: $sendEmailResponse" }
     }
+
+    fun generateTemplatePreview(templateId: String, personalisation: Map<String, Any>): NotifyTemplatePreviewDto =
+        notificationClient.generateTemplatePreview(templateId, personalisation).run {
+            NotifyTemplatePreviewDto(body, html.orElse(null))
+        }
 }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/dto/api/NotifyTemplatePreviewDto.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/dto/api/NotifyTemplatePreviewDto.kt
@@ -1,0 +1,6 @@
+package uk.gov.dluhc.notificationsapi.dto.api
+
+data class NotifyTemplatePreviewDto(
+    val text: String,
+    val html: String?
+)

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/client/GovNotifyApiClientIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/client/GovNotifyApiClientIntegrationTest.kt
@@ -1,0 +1,54 @@
+package uk.gov.dluhc.notificationsapi.client
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.dluhc.notificationsapi.config.IntegrationTest
+import uk.gov.dluhc.notificationsapi.dto.api.NotifyTemplatePreviewDto
+import uk.gov.dluhc.notificationsapi.testsupport.model.NotifyGenerateTemplatePreviewSuccessResponse
+import uk.gov.dluhc.notificationsapi.testsupport.model.NotifySendEmailSuccessResponse
+import java.time.LocalDate
+import java.util.UUID
+
+internal class GovNotifyApiClientIntegrationTest : IntegrationTest() {
+
+    @Nested
+    inner class SendEmail {
+        @Test
+        fun `should send email`() {
+            // Given
+            wireMockService.stubNotifySendEmailResponse(NotifySendEmailSuccessResponse())
+
+            // When
+            govNotifyApiClient.sendEmail()
+
+            // Then
+            wireMockService.verifyNotifySendEmailCalled()
+        }
+    }
+
+    @Nested
+    inner class GenerateTemplatePreview {
+        @Test
+        fun `should generate template preview`() {
+            // Given
+            val templateId = UUID.randomUUID().toString()
+            val response = NotifyGenerateTemplatePreviewSuccessResponse(id = templateId)
+            wireMockService.stubNotifyGenerateTemplatePreviewResponse(response)
+            val personalisation = mapOf(
+                "subject_param" to "test subject",
+                "name_param" to "John",
+                "custom_title" to "Resubmitting photo",
+                "date" to LocalDate.now()
+            )
+            val expected = NotifyTemplatePreviewDto(response.body, response.html)
+
+            // When
+            val actual = govNotifyApiClient.generateTemplatePreview(templateId, personalisation)
+
+            // Then
+            assertThat(actual).isEqualTo(expected)
+            wireMockService.verifyNotifyGenerateTemplatePreview(templateId, personalisation)
+        }
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/model/NotifyGenerateTemplatePreviewSuccessResponse.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/model/NotifyGenerateTemplatePreviewSuccessResponse.kt
@@ -1,0 +1,15 @@
+package uk.gov.dluhc.notificationsapi.testsupport.model
+
+import java.util.UUID
+
+/**
+ * Based on uk.gov.service.notify.TemplatePreview constructor JSON string parsing.
+ */
+data class NotifyGenerateTemplatePreviewSuccessResponse(
+    val id: String = UUID.randomUUID().toString(),
+    val type: String = "email",
+    val version: Int = 3,
+    val body: String = "Hi John",
+    val subject: String? = "Photo resubmission",
+    val html: String? = "<p style=\"Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;\">Hi John</p>"
+)


### PR DESCRIPTION
This PR is to add `generateTemplatePreview` method to the `GovNotifyApiClient`. 
This is only for the happy path scenario. 
Exception handling will be handled with the following subtasks.