### PR TITLE
EIP1-1934: EIP1-2044: Change personalisation to string map

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/client/GovNotifyApiClient.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/client/GovNotifyApiClient.kt
@@ -30,7 +30,7 @@ class GovNotifyApiClient(
         logger.info { "Email response: $sendEmailResponse" }
     }
 
-    fun generateTemplatePreview(templateId: String, personalisation: Map<String, Any>): NotifyTemplatePreviewDto =
+    fun generateTemplatePreview(templateId: String, personalisation: Map<String, String>): NotifyTemplatePreviewDto =
         notificationClient.generateTemplatePreview(templateId, personalisation).run {
             NotifyTemplatePreviewDto(body, subject.orElse(null), html.orElse(null))
         }

--- a/src/main/resources/openapi/NotificationsAPIs.yaml
+++ b/src/main/resources/openapi/NotificationsAPIs.yaml
@@ -162,7 +162,8 @@ components:
       properties:
         personalisation:
           type: object
-          additionalProperties: true
+          additionalProperties:
+            type: string
           description: Map of personalisation data
           example:
             name: Fred

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/client/GovNotifyApiClientIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/client/GovNotifyApiClientIntegrationTest.kt
@@ -9,7 +9,6 @@ import uk.gov.dluhc.notificationsapi.dto.api.NotifyTemplatePreviewDto
 import uk.gov.dluhc.notificationsapi.testsupport.model.NotifyGenerateTemplatePreviewSuccessResponse
 import uk.gov.dluhc.notificationsapi.testsupport.model.NotifySendEmailSuccessResponse
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.DataFaker
-import java.time.LocalDate
 import java.util.UUID
 
 internal class GovNotifyApiClientIntegrationTest : IntegrationTest() {
@@ -45,7 +44,6 @@ internal class GovNotifyApiClientIntegrationTest : IntegrationTest() {
                 "subject_param" to "test subject",
                 "name_param" to "John",
                 "custom_title" to "Resubmitting photo",
-                "date" to LocalDate.now()
             )
             val expected = with(response) { NotifyTemplatePreviewDto(body, subject, html) }
 

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/client/GovNotifyApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/client/GovNotifyApiClientTest.kt
@@ -22,7 +22,6 @@ import uk.gov.dluhc.notificationsapi.testsupport.testdata.DataFaker
 import uk.gov.service.notify.NotificationClient
 import uk.gov.service.notify.SendEmailResponse
 import uk.gov.service.notify.TemplatePreview
-import java.time.LocalDate
 import java.util.UUID
 
 @ExtendWith(MockitoExtension::class)
@@ -47,14 +46,16 @@ internal class GovNotifyApiClientTest {
             val templateId = UUID.randomUUID().toString()
             given(notificationTemplateMapper.fromNotificationType(any())).willReturn(templateId)
             val response =
-                NotifySendEmailSuccessResponse(template = Template(id = templateId), reference = notificationId.toString())
+                NotifySendEmailSuccessResponse(
+                    template = Template(id = templateId),
+                    reference = notificationId.toString()
+                )
             val objectMapper = ObjectMapper()
             val sendEmailResponse = SendEmailResponse(objectMapper.writeValueAsString(response))
             val personalisation = mapOf(
                 "subject_param" to "test subject",
                 "name_param" to "John",
-                "custom_title" to "Resubmitting photo",
-                "date" to LocalDate.now()
+                "custom_title" to "Resubmitting photo"
             )
             given(notificationClient.sendEmail(any(), any(), any(), any())).willReturn(sendEmailResponse)
 
@@ -88,7 +89,6 @@ internal class GovNotifyApiClientTest {
                 "subject_param" to "test subject",
                 "name_param" to "John",
                 "custom_title" to "Resubmitting photo",
-                "date" to LocalDate.now()
             )
             given(notificationClient.generateTemplatePreview(any(), any())).willReturn(previewResponse)
             val expected = NotifyTemplatePreviewDto(response.body, response.subject, html)


### PR DESCRIPTION
This PR is to change the personalisation parameter from Map<String, Object> to Map<String, String> as proposed by @Neil-Massey  and @NathanRussellValtech.