### PR TITLE
NO_JIRA: Override dynamodb endpoint locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The following environment variables must be set in order to run the application:
 * `AWS_SECRET_ACCESS_KEY` - the AWS secret access key
 * `AWS_REGION` - the AWS region
 * `SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI` - the uri of the cognito ERO user pool JWT issuer.
+* `DYNAMODB_ENDPOINT` - the localstack endpoint
 
 #### MYSQL Configuration
 For local setup refer to src/main/resources/db/readme.

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/config/AwsDynamoDbClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/config/AwsDynamoDbClientConfiguration.kt
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import java.net.URI
 
 @Configuration
 class AwsDynamoDbClientConfiguration {
@@ -18,13 +19,20 @@ class AwsDynamoDbClientConfiguration {
             .build()
 
     @Bean
-    fun dynamoDbClient(): DynamoDbClient = DynamoDbClient.builder()
-        .credentialsProvider(DefaultCredentialsProvider.create())
-        .build()
+    fun dynamoDbClient(dynamoDbConfiguration: DynamoDbConfiguration): DynamoDbClient {
+        val builder = DynamoDbClient.builder().credentialsProvider(DefaultCredentialsProvider.create())
+
+        if (dynamoDbConfiguration.endpoint != null) {
+            builder.endpointOverride(dynamoDbConfiguration.endpoint)
+        }
+
+        return builder.build()
+    }
 }
 
 @ConfigurationProperties(prefix = "dynamodb")
 @ConstructorBinding
 data class DynamoDbConfiguration(
     val notificationsTableName: String,
+    val endpoint: URI?
 )


### PR DESCRIPTION
This PR is to enable overriding of the DynamoDB endpoint by setting the DYNAMODB_ENDPOINT environment variable to enable the application to access the Localstack DynamoDB when running locally.