### PR TITLE
Revert "EIP1-3056: Adds applicationID to sqs message to determine an application at later date"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,9 +85,6 @@ dependencies {
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation("org.springframework.boot:spring-boot-starter-webflux")
 
-    // mongo core datatypes, so that we can generate a Mongo ObjectId (a 12 byte/24 char hex string ID)
-    testImplementation("org.mongodb:bson:4.8.1")
-
     testImplementation("org.testcontainers:junit-jupiter:1.17.6")
     testImplementation("org.testcontainers:testcontainers:1.17.6")
 

--- a/src/main/resources/openapi/sqs/Notifications-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/Notifications-sqs-messaging.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Notifications SQS Message Types
-  version: '1.4.2'
+  version: '1.4.1'
   description: |-
     Notifications SQS Message Types
     
@@ -48,11 +48,6 @@ components:
           $ref: '#/components/schemas/Language'
         sourceType:
           $ref: '#/components/schemas/SourceType'
-        applicationId:
-          type: string
-          pattern: '^[a-fA-F\d]{24}$'
-          description: The unique identifier of the Voter Card Application. A 24 character hex string.
-          example: 1f0f76a9a66f438b9bb33070
         sourceReference:
           type: string
           description: Reference in the source of the application this message relates
@@ -70,7 +65,6 @@ components:
         - channel
         - language
         - sourceType
-        - applicationId
         - sourceReference
         - gssCode
         - requestor

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/SendNotifyMessageMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/SendNotifyMessageMapperTest.kt
@@ -24,7 +24,6 @@ import uk.gov.dluhc.notificationsapi.testsupport.testdata.aGssCode
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aRequestor
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aSourceReference
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.anEmailAddress
-import uk.gov.dluhc.notificationsapi.testsupport.testdata.getIerDsApplicationId
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.messaging.models.buildPhotoResubmissionPersonalisationMessage
 import uk.gov.dluhc.notificationsapi.messaging.models.NotificationChannel as SqsChannel
 import uk.gov.dluhc.notificationsapi.messaging.models.SourceType as SqsSourceType
@@ -66,7 +65,6 @@ internal class SendNotifyMessageMapperTest {
             language = Language.EN,
             sourceType = SqsSourceType.VOTER_MINUS_CARD,
             sourceReference = sourceReference,
-            applicationId = getIerDsApplicationId(),
             gssCode = gssCode,
             requestor = requestor,
             messageType = MessageType.PHOTO_MINUS_RESUBMISSION,

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/CommonDataBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/CommonDataBuilder.kt
@@ -3,7 +3,6 @@ package uk.gov.dluhc.notificationsapi.testsupport.testdata
 import org.apache.commons.lang3.RandomStringUtils
 import org.apache.commons.lang3.RandomStringUtils.random
 import org.apache.commons.lang3.RandomStringUtils.randomNumeric
-import org.bson.types.ObjectId
 import uk.gov.dluhc.notificationsapi.dto.NotificationChannel
 import uk.gov.dluhc.notificationsapi.dto.NotificationType
 import uk.gov.dluhc.notificationsapi.dto.SourceType
@@ -42,9 +41,3 @@ fun aLocalDateTime(): LocalDateTime = LocalDateTime.of(2022, 10, 6, 9, 58, 24)
 fun aValidApplicationReference(): String = "V${RandomStringUtils.randomAlphabetic(9).uppercase()}"
 
 fun getAValidPostcode() = random(2, "ABEHW") + randomNumeric(2) + random(2, "ABEHW")
-
-/**
- * Returns a string that represents the IER application ID. IER uses mongodb ids ([ObjectId](https://www.mongodb.com/docs/manual/reference/method/ObjectId/))
- * which are 24 character wide hex strings.
- */
-fun getIerDsApplicationId(): String = ObjectId().toHexString()

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/messaging/models/SendNotifyPhotoResubmissionMessageBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/messaging/models/SendNotifyPhotoResubmissionMessageBuilder.kt
@@ -11,14 +11,12 @@ import uk.gov.dluhc.notificationsapi.testsupport.testdata.aGssCode
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aRequestor
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aSourceReference
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.anEmailAddress
-import uk.gov.dluhc.notificationsapi.testsupport.testdata.getIerDsApplicationId
 
 fun buildSendNotifyPhotoResubmissionMessage(
     channel: NotificationChannel = NotificationChannel.EMAIL,
     language: Language = Language.EN,
     sourceType: SourceType = SourceType.VOTER_MINUS_CARD,
     sourceReference: String = aSourceReference(),
-    applicationId: String = getIerDsApplicationId(),
     gssCode: String = aGssCode(),
     requestor: String = aRequestor(),
     messageType: MessageType = MessageType.PHOTO_MINUS_RESUBMISSION,
@@ -30,7 +28,6 @@ fun buildSendNotifyPhotoResubmissionMessage(
         language = language,
         sourceType = sourceType,
         sourceReference = sourceReference,
-        applicationId = applicationId,
         gssCode = gssCode,
         requestor = requestor,
         messageType = messageType,


### PR DESCRIPTION
Reverts cabinetoffice/eip-ero-notifications-api#44 as vca-api populates `sourceReference` with applicationId for RCA, print-api. So we wanted to be consistent across notifications-api as well. 