### PR TITLE
EIP1-3211 - Spec for RemoveApplicationNotificationsMessage SQS message

### DIFF
--- a/src/main/resources/openapi/sqs/Notifications-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/Notifications-sqs-messaging.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Notifications SQS Message Types
-  version: '1.4.3'
+  version: '1.4.4'
   description: |-
     Notifications SQS Message Types
     


### PR DESCRIPTION
This PR defines the `RemoveApplicationNotificationsMessage` for removing an application's notifications data, once the application's retention period has passed. This message will be sent from VCA to delete the relevant notifications data.

![image](https://user-images.githubusercontent.com/107410075/211516106-b27df60d-9d12-4913-bcd7-b3be70dbf951.png)
