### PR TITLE
EIP1-2182 Send photo and document resubmission comms by letter

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/client/GovNotifyApiClient.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/client/GovNotifyApiClient.kt
@@ -3,6 +3,7 @@ package uk.gov.dluhc.notificationsapi.client
 import mu.KotlinLogging
 import org.springframework.stereotype.Component
 import uk.gov.dluhc.notificationsapi.client.mapper.SendNotificationResponseMapper
+import uk.gov.dluhc.notificationsapi.dto.PostalAddress
 import uk.gov.dluhc.notificationsapi.dto.SendNotificationResponseDto
 import uk.gov.dluhc.notificationsapi.dto.api.NotifyTemplatePreviewDto
 import uk.gov.service.notify.NotificationClient
@@ -34,6 +35,24 @@ class GovNotifyApiClient(
                 }
         } catch (ex: NotificationClientException) {
             throw logAndThrowGovNotifyApiException("Send email", ex, templateId)
+        }
+    }
+
+    fun sendLetter(
+        templateId: String,
+        postalAddress: PostalAddress,
+        placeholders: Map<String, String>,
+        notificationId: UUID
+    ): SendNotificationResponseDto {
+        try {
+            logger.info { "Sending letter for templateId [$templateId], notificationId [$notificationId]" }
+            val personalisation = placeholders + postalAddress.toPersonalisationMap()
+            return notificationClient.sendLetter(templateId, personalisation, notificationId.toString())
+                .run {
+                    sendNotificationResponseMapper.toSendNotificationResponse(this)
+                }
+        } catch (ex: NotificationClientException) {
+            throw logAndThrowGovNotifyApiException("Send letter", ex, templateId)
         }
     }
 

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/client/mapper/SendNotificationResponseMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/client/mapper/SendNotificationResponseMapper.kt
@@ -5,6 +5,7 @@ import org.mapstruct.Mapping
 import org.mapstruct.Named
 import uk.gov.dluhc.notificationsapi.dto.SendNotificationResponseDto
 import uk.gov.service.notify.SendEmailResponse
+import uk.gov.service.notify.SendLetterResponse
 import java.util.Optional
 
 @Mapper
@@ -13,6 +14,9 @@ abstract class SendNotificationResponseMapper {
     @Mapping(source = "reference", target = "reference", qualifiedByName = ["unwrapString"])
     @Mapping(source = "fromEmail", target = "fromEmail", qualifiedByName = ["unwrapString"])
     abstract fun toSendNotificationResponse(sendEmailResponse: SendEmailResponse): SendNotificationResponseDto
+
+    @Mapping(source = "reference", target = "reference", qualifiedByName = ["unwrapString"])
+    abstract fun toSendNotificationResponse(sendLetterResponse: SendLetterResponse): SendNotificationResponseDto
 
     @Named("unwrapString")
     protected fun unwrapString(optional: Optional<String>): String? {

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/database/entity/Notification.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/database/entity/Notification.kt
@@ -17,6 +17,7 @@ data class Notification(
     var type: NotificationType? = null,
     var channel: Channel? = null,
     var toEmail: String? = null,
+    var toPostalAddress: PostalAddress? = null,
     var requestor: String? = null,
     var sentAt: LocalDateTime? = null,
     var personalisation: Map<String, String>? = null,

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/database/entity/PostalAddress.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/database/entity/PostalAddress.kt
@@ -1,0 +1,14 @@
+package uk.gov.dluhc.notificationsapi.database.entity
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean
+
+@DynamoDbBean
+data class PostalAddress(
+    var addressee: String? = null,
+    var `property`: String? = null,
+    var street: String? = null,
+    var town: String? = null,
+    var area: String? = null,
+    var locality: String? = null,
+    var postcode: String? = null,
+)

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/database/mapper/NotificationMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/database/mapper/NotificationMapper.kt
@@ -10,6 +10,8 @@ import uk.gov.dluhc.notificationsapi.mapper.NotificationTypeMapper
 import uk.gov.dluhc.notificationsapi.mapper.SourceTypeMapper
 import java.time.LocalDateTime
 import java.util.UUID
+import uk.gov.dluhc.notificationsapi.database.entity.PostalAddress as EntityPostalAddress
+import uk.gov.dluhc.notificationsapi.dto.PostalAddress as DtoPostalAddress
 
 @Mapper(uses = [SourceTypeMapper::class, NotificationTypeMapper::class])
 abstract class NotificationMapper {
@@ -20,7 +22,8 @@ abstract class NotificationMapper {
     @Mapping(target = "requestor", source = "request.requestor")
     @Mapping(target = "sourceReference", source = "request.sourceReference")
     @Mapping(target = "sourceType", source = "request.sourceType")
-    @Mapping(target = "toEmail", source = "request.emailAddress")
+    @Mapping(target = "toEmail", source = "request.toAddress.emailAddress")
+    @Mapping(target = "toPostalAddress", source = "request.toAddress.postalAddress")
     @Mapping(target = "personalisation", source = "personalisation")
     @Mapping(target = "notifyDetails", source = "sendNotificationResponse")
     @Mapping(target = "sentAt", source = "sentAt")
@@ -33,5 +36,6 @@ abstract class NotificationMapper {
         sentAt: LocalDateTime
     ): Notification
 
+    abstract fun toPostalAddress(postalAddress: DtoPostalAddress): EntityPostalAddress
     abstract fun toNotifyDetails(sendNotificationResponse: SendNotificationResponseDto): NotifyDetails
 }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/dto/NotificationDestinationDto.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/dto/NotificationDestinationDto.kt
@@ -1,0 +1,6 @@
+package uk.gov.dluhc.notificationsapi.dto
+
+data class NotificationDestinationDto(
+    val emailAddress: String?,
+    val postalAddress: PostalAddress?,
+)

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/dto/PostalAddress.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/dto/PostalAddress.kt
@@ -1,0 +1,28 @@
+package uk.gov.dluhc.notificationsapi.dto
+
+data class PostalAddress(
+    val addressee: String,
+    val property: String?,
+    val street: String,
+    val town: String?,
+    val area: String?,
+    val locality: String?,
+    val postcode: String,
+) {
+
+    /**
+     * Map the properties to the reserved Personalisation placeholders defined in the
+     * [Notify Service](https://docs.notifications.service.gov.uk/java.html#send-a-letter-arguments-personalisation-required)
+     */
+    fun toPersonalisationMap(): Map<String, String?> {
+        return mapOf(
+            "address_line_1" to addressee,
+            "address_line_2" to property,
+            "address_line_3" to street,
+            "address_line_4" to town,
+            "address_line_5" to area,
+            "address_line_6" to locality,
+            "address_line_7" to postcode,
+        )
+    }
+}

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/dto/SendNotificationRequestDto.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/dto/SendNotificationRequestDto.kt
@@ -7,6 +7,6 @@ data class SendNotificationRequestDto(
     val requestor: String,
     val sourceType: SourceType,
     val sourceReference: String,
-    val emailAddress: String,
+    val toAddress: NotificationDestinationDto,
     val notificationType: NotificationType,
 )

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/NotificationDestinationDtoMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/NotificationDestinationDtoMapper.kt
@@ -1,0 +1,20 @@
+package uk.gov.dluhc.notificationsapi.messaging.mapper
+
+import org.mapstruct.Mapper
+import org.mapstruct.Mapping
+import uk.gov.dluhc.notificationsapi.dto.NotificationDestinationDto
+import uk.gov.dluhc.notificationsapi.messaging.models.MessageAddress
+
+@Mapper
+interface NotificationDestinationDtoMapper {
+
+    @Mapping(target = "emailAddress", source = "emailAddress")
+    @Mapping(target = "postalAddress.addressee", source = "postalAddress.addressee")
+    @Mapping(target = "postalAddress.property", source = "postalAddress.address.property")
+    @Mapping(target = "postalAddress.street", source = "postalAddress.address.street")
+    @Mapping(target = "postalAddress.town", source = "postalAddress.address.town")
+    @Mapping(target = "postalAddress.area", source = "postalAddress.address.area")
+    @Mapping(target = "postalAddress.locality", source = "postalAddress.address.locality")
+    @Mapping(target = "postalAddress.postcode", source = "postalAddress.address.postcode")
+    fun toNotificationDestinationDto(toAddress: MessageAddress): NotificationDestinationDto
+}

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/SendNotifyMessageMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/SendNotifyMessageMapper.kt
@@ -9,17 +9,15 @@ import uk.gov.dluhc.notificationsapi.mapper.SourceTypeMapper
 import uk.gov.dluhc.notificationsapi.messaging.models.SendNotifyIdDocumentResubmissionMessage
 import uk.gov.dluhc.notificationsapi.messaging.models.SendNotifyPhotoResubmissionMessage
 
-@Mapper(uses = [LanguageMapper::class, SourceTypeMapper::class, NotificationTypeMapper::class])
+@Mapper(uses = [LanguageMapper::class, SourceTypeMapper::class, NotificationTypeMapper::class, NotificationDestinationDtoMapper::class])
 interface SendNotifyMessageMapper {
 
     @Mapping(target = "notificationType", source = "messageType")
-    @Mapping(target = "emailAddress", source = "message.toAddress.emailAddress")
     fun fromPhotoMessageToSendNotificationRequestDto(
         message: SendNotifyPhotoResubmissionMessage
     ): SendNotificationRequestDto
 
     @Mapping(target = "notificationType", source = "messageType")
-    @Mapping(target = "emailAddress", source = "message.toAddress.emailAddress")
     fun fromIdDocumentMessageToSendNotificationRequestDto(
         message: SendNotifyIdDocumentResubmissionMessage
     ): SendNotificationRequestDto

--- a/src/main/resources/openapi/sqs/Notifications-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/Notifications-sqs-messaging.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Notifications SQS Message Types
-  version: '1.4.4'
+  version: '1.5.0'
   description: |-
     Notifications SQS Message Types
     
@@ -271,6 +271,7 @@ components:
       type: string
       enum:
         - email
+        - letter
 
     SourceType:
       title: SourceType
@@ -298,20 +299,10 @@ components:
         postalAddress:
           type: object
           properties:
-            address_line_1:
+            addressee:
               type: string
-            address_line_2:
-              type: string
-            address_line_3:
-              type: string
-            address_line_4:
-              type: string
-            address_line_5:
-              type: string
-            address_line_6:
-              type: string
-            address_line_7:
-              type: string
+            address:
+              $ref: '#/components/schemas/Address'
         smsNumber:
           type: string
 

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/client/mapper/SendNotificationResponseDtoMapperTestDto.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/client/mapper/SendNotificationResponseDtoMapperTestDto.kt
@@ -4,17 +4,22 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.dluhc.notificationsapi.testsupport.model.Content
+import uk.gov.dluhc.notificationsapi.testsupport.model.LetterContent
+import uk.gov.dluhc.notificationsapi.testsupport.model.LetterTemplate
 import uk.gov.dluhc.notificationsapi.testsupport.model.NotifySendEmailSuccessResponse
+import uk.gov.dluhc.notificationsapi.testsupport.model.NotifySendLetterSuccessResponse
 import uk.gov.dluhc.notificationsapi.testsupport.model.Template
-import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendEmailSuccessResponseBody
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendEmailSuccessResponseFromEmail
-import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendEmailSuccessResponseId
-import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendEmailSuccessResponseReference
-import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendEmailSuccessResponseSubject
-import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendEmailSuccessResponseTemplateId
-import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendEmailSuccessResponseTemplateUri
-import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendEmailSuccessResponseTemplateVersion
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendLetterSuccessResponsePostage
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendSuccessResponseBody
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendSuccessResponseId
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendSuccessResponseReference
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendSuccessResponseSubject
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendSuccessResponseTemplateId
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendSuccessResponseTemplateUri
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendSuccessResponseTemplateVersion
 import uk.gov.service.notify.SendEmailResponse
+import uk.gov.service.notify.SendLetterResponse
 
 class SendNotificationResponseDtoMapperTestDto {
 
@@ -24,13 +29,13 @@ class SendNotificationResponseDtoMapperTestDto {
     @Test
     fun `should map from SendEmailResponse to NotifySendEmailSuccessResponse`() {
         // Given
-        val expectedNotificationId = aNotifySendEmailSuccessResponseId()
-        val expectedReference = aNotifySendEmailSuccessResponseReference()
-        val expectedTemplateId = aNotifySendEmailSuccessResponseTemplateId()
-        val expectedTemplateVersion = aNotifySendEmailSuccessResponseTemplateVersion()
-        val expectedTemplateUri: String = aNotifySendEmailSuccessResponseTemplateUri(expectedTemplateId)
-        val expectedBody: String = aNotifySendEmailSuccessResponseBody()
-        val expectedSubject: String = aNotifySendEmailSuccessResponseSubject()
+        val expectedNotificationId = aNotifySendSuccessResponseId()
+        val expectedReference = aNotifySendSuccessResponseReference()
+        val expectedTemplateId = aNotifySendSuccessResponseTemplateId()
+        val expectedTemplateVersion = aNotifySendSuccessResponseTemplateVersion()
+        val expectedTemplateUri: String = aNotifySendSuccessResponseTemplateUri(expectedTemplateId)
+        val expectedBody: String = aNotifySendSuccessResponseBody()
+        val expectedSubject: String = aNotifySendSuccessResponseSubject()
         val expectedFromEmail = aNotifySendEmailSuccessResponseFromEmail()
 
         val response =
@@ -63,5 +68,49 @@ class SendNotificationResponseDtoMapperTestDto {
         assertThat(actual.body).isEqualTo(expectedBody)
         assertThat(actual.subject).isEqualTo(expectedSubject)
         assertThat(actual.fromEmail).isEqualTo(expectedFromEmail)
+    }
+
+    @Test
+    fun `should map from SendLetterResponse to NotifySendLetterSuccessResponse`() {
+        // Given
+        val expectedNotificationId = aNotifySendSuccessResponseId()
+        val expectedReference = aNotifySendSuccessResponseReference()
+        val expectedTemplateId = aNotifySendSuccessResponseTemplateId()
+        val expectedTemplateVersion = aNotifySendSuccessResponseTemplateVersion()
+        val expectedTemplateUri: String = aNotifySendSuccessResponseTemplateUri(expectedTemplateId)
+        val expectedBody: String = aNotifySendSuccessResponseBody()
+        val expectedSubject: String = aNotifySendSuccessResponseSubject()
+        val expectedPostage = aNotifySendLetterSuccessResponsePostage()
+
+        val response =
+            NotifySendLetterSuccessResponse(
+                id = expectedNotificationId.toString(),
+                reference = expectedReference,
+                postage = expectedPostage,
+                template = LetterTemplate(
+                    id = expectedTemplateId.toString(),
+                    version = expectedTemplateVersion.toString(),
+                    uri = expectedTemplateUri
+                ),
+                content = LetterContent(
+                    body = expectedBody,
+                    subject = expectedSubject
+                )
+            )
+        val objectMapper = ObjectMapper()
+        val sendLetterResponse = SendLetterResponse(objectMapper.writeValueAsString(response))
+
+        // When
+        val actual = mapper.toSendNotificationResponse(sendLetterResponse)
+
+        // Then
+        assertThat(actual.notificationId).isEqualTo(expectedNotificationId)
+        assertThat(actual.reference).isEqualTo(expectedReference)
+        assertThat(actual.templateId).isEqualTo(expectedTemplateId)
+        assertThat(actual.templateVersion).isEqualTo(expectedTemplateVersion)
+        assertThat(actual.templateUri).isEqualTo(expectedTemplateUri)
+        assertThat(actual.body).isEqualTo(expectedBody)
+        assertThat(actual.subject).isEqualTo(expectedSubject)
+        assertThat(actual.fromEmail).isNull()
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/database/mapper/NotificationMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/database/mapper/NotificationMapperTest.kt
@@ -1,6 +1,6 @@
 package uk.gov.dluhc.notificationsapi.database.mapper
 
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
@@ -10,11 +10,14 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
 import uk.gov.dluhc.notificationsapi.database.entity.NotificationType
+import uk.gov.dluhc.notificationsapi.dto.NotificationDestinationDto
 import uk.gov.dluhc.notificationsapi.dto.NotificationType.PHOTO_RESUBMISSION
+import uk.gov.dluhc.notificationsapi.dto.PostalAddress
 import uk.gov.dluhc.notificationsapi.dto.SendNotificationResponseDto
 import uk.gov.dluhc.notificationsapi.dto.SourceType
 import uk.gov.dluhc.notificationsapi.mapper.NotificationTypeMapper
 import uk.gov.dluhc.notificationsapi.mapper.SourceTypeMapper
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.DataFaker.Companion.faker
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aGssCode
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aLocalDateTime
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aNotificationId
@@ -22,10 +25,10 @@ import uk.gov.dluhc.notificationsapi.testsupport.testdata.aRequestor
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aSourceReference
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.anEmailAddress
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.database.entity.aNotifyDetails
-import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendEmailSuccessResponseBody
-import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendEmailSuccessResponseSubject
-import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendEmailSuccessResponseTemplateUri
-import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendEmailSuccessResponseTemplateVersion
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendSuccessResponseBody
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendSuccessResponseSubject
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendSuccessResponseTemplateUri
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendSuccessResponseTemplateVersion
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aSendNotificationDto
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aTemplateId
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.buildPhotoPersonalisationDto
@@ -51,10 +54,10 @@ internal class NotificationMapperTest {
         val notificationId = aNotificationId()
         val reference = aSourceReference()
         val templateId = aTemplateId()
-        val templateVersion = aNotifySendEmailSuccessResponseTemplateVersion()
-        val templateUri = aNotifySendEmailSuccessResponseTemplateUri(templateId)
-        val body = aNotifySendEmailSuccessResponseBody()
-        val subject = aNotifySendEmailSuccessResponseSubject()
+        val templateVersion = aNotifySendSuccessResponseTemplateVersion()
+        val templateUri = aNotifySendSuccessResponseTemplateUri(templateId)
+        val body = aNotifySendSuccessResponseBody()
+        val subject = aNotifySendSuccessResponseSubject()
         val fromEmail = anEmailAddress()
 
         val sendNotificationResponseDto = SendNotificationResponseDto(
@@ -72,14 +75,48 @@ internal class NotificationMapperTest {
         val actual = mapper.toNotifyDetails(sendNotificationResponseDto)
 
         // Then
-        Assertions.assertThat(actual.notificationId).isEqualTo(notificationId)
-        Assertions.assertThat(actual.reference).isEqualTo(reference)
-        Assertions.assertThat(actual.templateId).isEqualTo(templateId)
-        Assertions.assertThat(actual.templateVersion).isEqualTo(templateVersion)
-        Assertions.assertThat(actual.templateUri).isEqualTo(templateUri)
-        Assertions.assertThat(actual.body).isEqualTo(body)
-        Assertions.assertThat(actual.subject).isEqualTo(subject)
-        Assertions.assertThat(actual.fromEmail).isEqualTo(fromEmail)
+        assertThat(actual.notificationId).isEqualTo(notificationId)
+        assertThat(actual.reference).isEqualTo(reference)
+        assertThat(actual.templateId).isEqualTo(templateId)
+        assertThat(actual.templateVersion).isEqualTo(templateVersion)
+        assertThat(actual.templateUri).isEqualTo(templateUri)
+        assertThat(actual.body).isEqualTo(body)
+        assertThat(actual.subject).isEqualTo(subject)
+        assertThat(actual.fromEmail).isEqualTo(fromEmail)
+    }
+
+    @Test
+    fun `should map to PostalAddress`() {
+        // Given
+        val addressee = faker.name().firstName()
+        val property = faker.address().buildingNumber()
+        val street = faker.address().streetName()
+        val town = faker.address().streetName()
+        val area = faker.address().city()
+        val locality = faker.address().state()
+        val postcode = faker.address().postcode()
+
+        val postalAddressDto = PostalAddress(
+            addressee = addressee,
+            property = property,
+            street = street,
+            town = town,
+            area = area,
+            locality = locality,
+            postcode = postcode,
+        )
+
+        // When
+        val actual = mapper.toPostalAddress(postalAddressDto)
+
+        // Then
+        assertThat(actual.addressee).isEqualTo(addressee)
+        assertThat(actual.property).isEqualTo(property)
+        assertThat(actual.street).isEqualTo(street)
+        assertThat(actual.town).isEqualTo(town)
+        assertThat(actual.area).isEqualTo(area)
+        assertThat(actual.locality).isEqualTo(locality)
+        assertThat(actual.postcode).isEqualTo(postcode)
     }
 
     @Test
@@ -100,7 +137,7 @@ internal class NotificationMapperTest {
             requestor = requestor,
             sourceType = sourceType,
             sourceReference = sourceReference,
-            emailAddress = emailAddress,
+            toAddress = NotificationDestinationDto(emailAddress = anEmailAddress(), postalAddress = null),
             notificationType = notificationType,
         )
         val personalisationMap = buildPhotoPersonalisationMapFromDto(personalisationDto)
@@ -115,16 +152,16 @@ internal class NotificationMapperTest {
         val notification = mapper.createNotification(notificationId, request, personalisationMap, sendNotificationResponseDto, sentAt)
 
         // Then
-        Assertions.assertThat(notification.id).isEqualTo(notificationId)
-        Assertions.assertThat(notification.type).isEqualTo(expectedNotificationType)
-        Assertions.assertThat(notification.gssCode).isEqualTo(gssCode)
-        Assertions.assertThat(notification.requestor).isEqualTo(requestor)
-        Assertions.assertThat(notification.sourceType).isEqualTo(expectedSourceType)
-        Assertions.assertThat(notification.sourceReference).isEqualTo(sourceReference)
-        Assertions.assertThat(notification.toEmail).isEqualTo(emailAddress)
-        Assertions.assertThat(notification.personalisation).isEqualTo(personalisationMap)
-        Assertions.assertThat(notification.notifyDetails).isEqualTo(expectedNotifyDetails)
-        Assertions.assertThat(notification.sentAt).isEqualTo(sentAt)
+        assertThat(notification.id).isEqualTo(notificationId)
+        assertThat(notification.type).isEqualTo(expectedNotificationType)
+        assertThat(notification.gssCode).isEqualTo(gssCode)
+        assertThat(notification.requestor).isEqualTo(requestor)
+        assertThat(notification.sourceType).isEqualTo(expectedSourceType)
+        assertThat(notification.sourceReference).isEqualTo(sourceReference)
+        assertThat(notification.toEmail).isEqualTo(emailAddress)
+        assertThat(notification.personalisation).isEqualTo(personalisationMap)
+        assertThat(notification.notifyDetails).isEqualTo(expectedNotifyDetails)
+        assertThat(notification.sentAt).isEqualTo(sentAt)
 
         verify(notificationTypeMapper).toNotificationTypeEntity(PHOTO_RESUBMISSION)
         verify(sourceTypeMapper).toSourceTypeEntity(SourceType.VOTER_CARD)

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/dto/PostalAddressTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/dto/PostalAddressTest.kt
@@ -1,0 +1,44 @@
+package uk.gov.dluhc.notificationsapi.dto
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.DataFaker.Companion.faker
+
+internal class PostalAddressTest {
+
+    @Test
+    fun `should convert toPersonalisationMap`() {
+        // Given
+        val addressee = faker.name().firstName()
+        val property = faker.address().streetName()
+        val street = faker.address().buildingNumber()
+        val town = faker.address().streetName()
+        val area = faker.address().city()
+        val locality = faker.address().state()
+        val postcode = faker.address().postcode()
+        val postalAddress = PostalAddress(
+            addressee = addressee,
+            property = property,
+            street = street,
+            town = town,
+            area = area,
+            locality = locality,
+            postcode = postcode,
+        )
+        val expected = mapOf(
+            "address_line_1" to addressee,
+            "address_line_2" to property,
+            "address_line_3" to street,
+            "address_line_4" to town,
+            "address_line_5" to area,
+            "address_line_6" to locality,
+            "address_line_7" to postcode,
+        )
+
+        // When
+        val actual = postalAddress.toPersonalisationMap()
+
+        // Then
+        assertThat(actual).isEqualTo(expected)
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyIdDocumentResubmissionMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyIdDocumentResubmissionMessageListenerIntegrationTest.kt
@@ -11,6 +11,7 @@ import uk.gov.dluhc.notificationsapi.messaging.models.Language
 import uk.gov.dluhc.notificationsapi.messaging.models.NotificationChannel
 import uk.gov.dluhc.notificationsapi.messaging.models.SourceType
 import uk.gov.dluhc.notificationsapi.testsupport.model.NotifySendEmailSuccessResponse
+import uk.gov.dluhc.notificationsapi.testsupport.model.NotifySendLetterSuccessResponse
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aGssCode
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aRandomSourceReference
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.messaging.models.buildSendNotifyIdDocumentResubmissionMessage
@@ -46,6 +47,39 @@ internal class SendNotifyIdDocumentResubmissionMessageListenerIntegrationTest : 
         val stopWatch = StopWatch.createStarted()
         await.atMost(3, TimeUnit.SECONDS).untilAsserted {
             wireMockService.verifyNotifySendEmailCalled()
+            val actualEntity = notificationRepository.getBySourceReference(sourceReference, gssCode)
+            Assertions.assertThat(actualEntity).hasSize(1)
+            stopWatch.stop()
+            logger.info("completed assertions in $stopWatch for language $language")
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(Language::class)
+    fun `should process ID document message to send Letter for given language and save notification`(
+        language: Language
+    ) {
+        // Given
+        val gssCode = aGssCode()
+        val sourceType = SourceType.VOTER_MINUS_CARD
+        val sourceReference = aRandomSourceReference()
+        val payload = buildSendNotifyIdDocumentResubmissionMessage(
+            channel = NotificationChannel.LETTER,
+            language = language,
+            gssCode = gssCode,
+            sourceType = sourceType,
+            sourceReference = sourceReference
+        )
+        deleteNotifications(notificationRepository.getBySourceReference(sourceReference, gssCode))
+        wireMockService.stubNotifySendLetterResponse(NotifySendLetterSuccessResponse())
+
+        // When
+        sqsMessagingTemplate.convertAndSend(sendUkGovNotifyIdDocumentResubmissionQueueName, payload)
+
+        // Then
+        val stopWatch = StopWatch.createStarted()
+        await.atMost(3000, TimeUnit.SECONDS).untilAsserted {
+            wireMockService.verifyNotifySendLetterCalled()
             val actualEntity = notificationRepository.getBySourceReference(sourceReference, gssCode)
             Assertions.assertThat(actualEntity).hasSize(1)
             stopWatch.stop()

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/NotificationDestinationDtoMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/NotificationDestinationDtoMapperTest.kt
@@ -1,0 +1,85 @@
+package uk.gov.dluhc.notificationsapi.messaging.mapper
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.dluhc.notificationsapi.dto.NotificationDestinationDto
+import uk.gov.dluhc.notificationsapi.dto.PostalAddress
+import uk.gov.dluhc.notificationsapi.messaging.models.Address
+import uk.gov.dluhc.notificationsapi.messaging.models.MessageAddress
+import uk.gov.dluhc.notificationsapi.messaging.models.MessageAddressPostalAddress
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.DataFaker.Companion.faker
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.anEmailAddress
+
+internal class NotificationDestinationDtoMapperTest {
+
+    private val mapper: NotificationDestinationDtoMapper =
+        NotificationDestinationDtoMapperImpl()
+
+    @Test
+    fun `should map SQS MessageAddress to NotificationDestinationDto for Email Address`() {
+        // Given
+        val email: String = anEmailAddress()
+
+        val expectedDestination = NotificationDestinationDto(
+            emailAddress = email,
+            postalAddress = null
+        )
+
+        val request = MessageAddress(
+            emailAddress = email,
+            postalAddress = null,
+        )
+
+        // When
+        val destination = mapper.toNotificationDestinationDto(request)
+
+        // Then
+        assertThat(destination).isEqualTo(expectedDestination)
+    }
+
+    @Test
+    fun `should map SQS MessageAddress to NotificationDestinationDto for Postal Address`() {
+        // Given
+        val addressee: String = faker.name().firstName()
+        val property: String = faker.address().streetName()
+        val street: String = faker.address().buildingNumber()
+        val town: String? = faker.address().streetName()
+        val area: String? = faker.address().city()
+        val locality: String? = faker.address().state()
+        val postcode: String = faker.address().postcode()
+
+        val expectedDestination = NotificationDestinationDto(
+            emailAddress = null,
+            postalAddress = PostalAddress(
+                addressee = addressee,
+                property = property,
+                street = street,
+                town = town,
+                area = area,
+                locality = locality,
+                postcode = postcode,
+            )
+        )
+
+        val request = MessageAddress(
+            emailAddress = null,
+            postalAddress = MessageAddressPostalAddress(
+                addressee = addressee,
+                address = Address(
+                    property = property,
+                    street = street,
+                    town = town,
+                    area = area,
+                    locality = locality,
+                    postcode = postcode
+                ),
+            )
+        )
+
+        // When
+        val destination = mapper.toNotificationDestinationDto(request)
+
+        // Then
+        assertThat(destination).isEqualTo(expectedDestination)
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/SendNotifyMessageMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/SendNotifyMessageMapperTest.kt
@@ -18,14 +18,14 @@ import uk.gov.dluhc.notificationsapi.mapper.LanguageMapper
 import uk.gov.dluhc.notificationsapi.mapper.NotificationTypeMapper
 import uk.gov.dluhc.notificationsapi.mapper.SourceTypeMapper
 import uk.gov.dluhc.notificationsapi.messaging.models.Language
-import uk.gov.dluhc.notificationsapi.messaging.models.MessageAddress
 import uk.gov.dluhc.notificationsapi.messaging.models.MessageType
 import uk.gov.dluhc.notificationsapi.messaging.models.SendNotifyIdDocumentResubmissionMessage
 import uk.gov.dluhc.notificationsapi.messaging.models.SendNotifyPhotoResubmissionMessage
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aGssCode
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aRequestor
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aSourceReference
-import uk.gov.dluhc.notificationsapi.testsupport.testdata.anEmailAddress
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotificationDestination
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.messaging.models.aMessageAddress
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.messaging.models.buildIdDocumentPersonalisationMessage
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.messaging.models.buildPhotoPersonalisationMessage
 import uk.gov.dluhc.notificationsapi.messaging.models.NotificationChannel as SqsChannel
@@ -46,13 +46,17 @@ internal class SendNotifyMessageMapperTest {
     @Mock
     private lateinit var sourceTypeMapper: SourceTypeMapper
 
+    @Mock
+    private lateinit var notificationDestinationDtoMapper: NotificationDestinationDtoMapper
+
     @Test
     fun `should map SQS SendNotifyPhotoResubmissionMessage to SendNotificationRequestDto`() {
         // Given
         val gssCode = aGssCode()
         val requestor = aRequestor()
         val sourceReference = aSourceReference()
-        val emailAddress = anEmailAddress()
+        val toAddress = aMessageAddress()
+        val expectedToAddress = aNotificationDestination()
         val expectedChannel = NotificationChannel.EMAIL
         val expectedSourceType = SourceType.VOTER_CARD
         val expectedNotificationType = PHOTO_RESUBMISSION
@@ -62,6 +66,7 @@ internal class SendNotifyMessageMapperTest {
         given(languageMapper.fromMessageToDto(any())).willReturn(expectedLanguage)
         given(notificationTypeMapper.mapMessageTypeToNotificationType(any())).willReturn(expectedNotificationType)
         given(sourceTypeMapper.toSourceTypeDto(any())).willReturn(expectedSourceType)
+        given(notificationDestinationDtoMapper.toNotificationDestinationDto(any())).willReturn(expectedToAddress)
 
         val request = SendNotifyPhotoResubmissionMessage(
             channel = SqsChannel.EMAIL,
@@ -71,7 +76,7 @@ internal class SendNotifyMessageMapperTest {
             gssCode = gssCode,
             requestor = requestor,
             messageType = MessageType.PHOTO_MINUS_RESUBMISSION,
-            toAddress = MessageAddress(emailAddress = emailAddress),
+            toAddress = toAddress,
             personalisation = personalisationMessage,
         )
 
@@ -85,10 +90,11 @@ internal class SendNotifyMessageMapperTest {
         assertThat(notification.gssCode).isEqualTo(gssCode)
         assertThat(notification.requestor).isEqualTo(requestor)
         assertThat(notification.notificationType).isEqualTo(expectedNotificationType)
-        assertThat(notification.emailAddress).isEqualTo(emailAddress)
+        assertThat(notification.toAddress).isEqualTo(expectedToAddress)
         verify(languageMapper).fromMessageToDto(Language.EN)
         verify(notificationTypeMapper).mapMessageTypeToNotificationType(MessageType.PHOTO_MINUS_RESUBMISSION)
         verify(sourceTypeMapper).toSourceTypeDto(SqsSourceType.VOTER_MINUS_CARD)
+        verify(notificationDestinationDtoMapper).toNotificationDestinationDto(toAddress)
     }
 
     @Test
@@ -97,7 +103,8 @@ internal class SendNotifyMessageMapperTest {
         val gssCode = aGssCode()
         val requestor = aRequestor()
         val sourceReference = aSourceReference()
-        val emailAddress = anEmailAddress()
+        val toAddress = aMessageAddress()
+        val expectedToAddress = aNotificationDestination()
         val expectedChannel = NotificationChannel.EMAIL
         val expectedSourceType = SourceType.VOTER_CARD
         val expectedNotificationType = ID_DOCUMENT_RESUBMISSION
@@ -107,6 +114,7 @@ internal class SendNotifyMessageMapperTest {
         given(languageMapper.fromMessageToDto(any())).willReturn(expectedLanguage)
         given(notificationTypeMapper.mapMessageTypeToNotificationType(any())).willReturn(expectedNotificationType)
         given(sourceTypeMapper.toSourceTypeDto(any())).willReturn(expectedSourceType)
+        given(notificationDestinationDtoMapper.toNotificationDestinationDto(any())).willReturn(expectedToAddress)
 
         val request = SendNotifyIdDocumentResubmissionMessage(
             channel = SqsChannel.EMAIL,
@@ -116,7 +124,7 @@ internal class SendNotifyMessageMapperTest {
             gssCode = gssCode,
             requestor = requestor,
             messageType = MessageType.ID_MINUS_DOCUMENT_MINUS_RESUBMISSION,
-            toAddress = MessageAddress(emailAddress = emailAddress),
+            toAddress = toAddress,
             personalisation = personalisationMessage,
         )
 
@@ -130,9 +138,10 @@ internal class SendNotifyMessageMapperTest {
         assertThat(notification.gssCode).isEqualTo(gssCode)
         assertThat(notification.requestor).isEqualTo(requestor)
         assertThat(notification.notificationType).isEqualTo(expectedNotificationType)
-        assertThat(notification.emailAddress).isEqualTo(emailAddress)
+        assertThat(notification.toAddress).isEqualTo(expectedToAddress)
         verify(languageMapper).fromMessageToDto(Language.EN)
         verify(notificationTypeMapper).mapMessageTypeToNotificationType(MessageType.ID_MINUS_DOCUMENT_MINUS_RESUBMISSION)
         verify(sourceTypeMapper).toSourceTypeDto(SqsSourceType.VOTER_MINUS_CARD)
+        verify(notificationDestinationDtoMapper).toNotificationDestinationDto(toAddress)
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/model/NotifySendLetterSuccessResponse.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/model/NotifySendLetterSuccessResponse.kt
@@ -1,0 +1,24 @@
+package uk.gov.dluhc.notificationsapi.testsupport.model
+
+/**
+ * Based on uk.gov.service.notify.SendLetterResponse constructor JSON string parsing.
+ */
+
+data class NotifySendLetterSuccessResponse(
+    val id: String = "ad0bf394-9000-4c9b-8a0c-734fef454ee4",
+    var reference: String? = "Our reference",
+    var postage: String? = "second",
+    val content: LetterContent = LetterContent(),
+    val template: LetterTemplate = LetterTemplate()
+)
+
+data class LetterContent(
+    val body: String = "Body content of letter",
+    val subject: String = "Subject of letter",
+)
+
+data class LetterTemplate(
+    val id: String = "e6de9bf4-3757-4e5f-a9a4-a449616ec6d2",
+    val version: String = "1",
+    val uri: String = "https://www.notifications.service.gov.uk/services/137e13d7-6acd-4449-815e-de0eb0c083ba/templates/e6de9bf4-3757-4e5f-a9a4-a449616ec6d2/1"
+)

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/CommonDataBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/CommonDataBuilder.kt
@@ -5,7 +5,9 @@ import org.apache.commons.lang3.RandomStringUtils.random
 import org.apache.commons.lang3.RandomStringUtils.randomNumeric
 import uk.gov.dluhc.notificationsapi.dto.NotificationChannel
 import uk.gov.dluhc.notificationsapi.dto.NotificationType
+import uk.gov.dluhc.notificationsapi.dto.PostalAddress
 import uk.gov.dluhc.notificationsapi.dto.SourceType
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.DataFaker.Companion.faker
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -41,3 +43,21 @@ fun aLocalDateTime(): LocalDateTime = LocalDateTime.of(2022, 10, 6, 9, 58, 24)
 fun aValidApplicationReference(): String = "V${RandomStringUtils.randomAlphabetic(9).uppercase()}"
 
 fun getAValidPostcode() = random(2, "ABEHW") + randomNumeric(2) + random(2, "ABEHW")
+
+fun aPostalAddress(
+    addressee: String = faker.name().firstName(),
+    property: String? = faker.address().buildingNumber(),
+    street: String = faker.address().streetName(),
+    town: String? = faker.address().streetName(),
+    area: String? = faker.address().city(),
+    locality: String? = faker.address().state(),
+    postcode: String = faker.address().postcode(),
+) = PostalAddress(
+    addressee = addressee,
+    property = property,
+    street = street,
+    town = town,
+    area = area,
+    locality = locality,
+    postcode = postcode,
+)

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/database/entity/NotifyDetailsBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/database/entity/NotifyDetailsBuilder.kt
@@ -2,24 +2,24 @@ package uk.gov.dluhc.notificationsapi.testsupport.testdata.database.entity
 
 import uk.gov.dluhc.notificationsapi.database.entity.NotifyDetails
 import uk.gov.dluhc.notificationsapi.dto.SendNotificationResponseDto
-import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendEmailSuccessResponseBody
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendEmailSuccessResponseFromEmail
-import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendEmailSuccessResponseId
-import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendEmailSuccessResponseReference
-import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendEmailSuccessResponseSubject
-import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendEmailSuccessResponseTemplateId
-import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendEmailSuccessResponseTemplateUri
-import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendEmailSuccessResponseTemplateVersion
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendSuccessResponseBody
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendSuccessResponseId
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendSuccessResponseReference
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendSuccessResponseSubject
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendSuccessResponseTemplateId
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendSuccessResponseTemplateUri
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotifySendSuccessResponseTemplateVersion
 import java.util.UUID
 
 fun buildNotifyDetails(
-    notificationId: UUID = aNotifySendEmailSuccessResponseId(),
-    reference: String = aNotifySendEmailSuccessResponseReference(),
-    templateId: UUID = aNotifySendEmailSuccessResponseTemplateId(),
-    templateVersion: Int = aNotifySendEmailSuccessResponseTemplateVersion(),
-    templateUri: String = aNotifySendEmailSuccessResponseTemplateUri(templateId),
-    body: String = aNotifySendEmailSuccessResponseBody(),
-    subject: String = aNotifySendEmailSuccessResponseSubject(),
+    notificationId: UUID = aNotifySendSuccessResponseId(),
+    reference: String = aNotifySendSuccessResponseReference(),
+    templateId: UUID = aNotifySendSuccessResponseTemplateId(),
+    templateVersion: Int = aNotifySendSuccessResponseTemplateVersion(),
+    templateUri: String = aNotifySendSuccessResponseTemplateUri(templateId),
+    body: String = aNotifySendSuccessResponseBody(),
+    subject: String = aNotifySendSuccessResponseSubject(),
     fromEmail: String? = aNotifySendEmailSuccessResponseFromEmail(),
 ): NotifyDetails =
     NotifyDetails(

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/dto/NotificationDestinationDtoBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/dto/NotificationDestinationDtoBuilder.kt
@@ -1,0 +1,15 @@
+package uk.gov.dluhc.notificationsapi.testsupport.testdata.dto
+
+import uk.gov.dluhc.notificationsapi.dto.NotificationDestinationDto
+import uk.gov.dluhc.notificationsapi.dto.PostalAddress
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.aPostalAddress
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.anEmailAddress
+
+fun aNotificationDestination(
+    emailAddress: String? = anEmailAddress(),
+    postalAddress: PostalAddress = aPostalAddress()
+): NotificationDestinationDto =
+    NotificationDestinationDto(
+        emailAddress = emailAddress,
+        postalAddress = postalAddress
+    )

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/dto/SendNotificationDtoBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/dto/SendNotificationDtoBuilder.kt
@@ -5,13 +5,13 @@ import java.util.UUID
 import java.util.concurrent.ThreadLocalRandom
 
 fun buildSendNotificationDto(
-    notificationId: UUID = aNotifySendEmailSuccessResponseId(),
-    reference: String = aNotifySendEmailSuccessResponseReference(),
-    templateId: UUID = aNotifySendEmailSuccessResponseTemplateId(),
-    templateVersion: Int = aNotifySendEmailSuccessResponseTemplateVersion(),
-    templateUri: String = aNotifySendEmailSuccessResponseTemplateUri(templateId),
-    body: String = aNotifySendEmailSuccessResponseBody(),
-    subject: String = aNotifySendEmailSuccessResponseSubject(),
+    notificationId: UUID = aNotifySendSuccessResponseId(),
+    reference: String = aNotifySendSuccessResponseReference(),
+    templateId: UUID = aNotifySendSuccessResponseTemplateId(),
+    templateVersion: Int = aNotifySendSuccessResponseTemplateVersion(),
+    templateUri: String = aNotifySendSuccessResponseTemplateUri(templateId),
+    body: String = aNotifySendSuccessResponseBody(),
+    subject: String = aNotifySendSuccessResponseSubject(),
     fromEmail: String? = aNotifySendEmailSuccessResponseFromEmail(),
 ): SendNotificationResponseDto =
     SendNotificationResponseDto(
@@ -27,20 +27,22 @@ fun buildSendNotificationDto(
 
 fun aSendNotificationDto() = buildSendNotificationDto()
 
-fun aNotifySendEmailSuccessResponseId(): UUID = UUID.randomUUID()
+fun aNotifySendSuccessResponseId(): UUID = UUID.randomUUID()
 
-fun aNotifySendEmailSuccessResponseReference(): String = UUID.randomUUID().toString()
+fun aNotifySendSuccessResponseReference(): String = UUID.randomUUID().toString()
 
 fun aTemplateId(): UUID = UUID.randomUUID()
 
-fun aNotifySendEmailSuccessResponseTemplateId(): UUID = aTemplateId()
+fun aNotifySendSuccessResponseTemplateId(): UUID = aTemplateId()
 
-fun aNotifySendEmailSuccessResponseTemplateVersion(): Int = ThreadLocalRandom.current().nextInt(1, 100)
+fun aNotifySendSuccessResponseTemplateVersion(): Int = ThreadLocalRandom.current().nextInt(1, 100)
 
-fun aNotifySendEmailSuccessResponseTemplateUri(templateId: UUID): String = "https://www.notifications.service.gov.uk/services/137e13d7-6acd-4449-815e-de0eb0c083ba/templates/$templateId"
+fun aNotifySendSuccessResponseTemplateUri(templateId: UUID): String = "https://www.notifications.service.gov.uk/services/137e13d7-6acd-4449-815e-de0eb0c083ba/templates/$templateId"
 
-fun aNotifySendEmailSuccessResponseBody(): String = "Hello John..."
+fun aNotifySendSuccessResponseBody(): String = "Hello John..."
 
-fun aNotifySendEmailSuccessResponseSubject(): String = "Application Photo Declined"
+fun aNotifySendSuccessResponseSubject(): String = "Application Photo Declined"
 
 fun aNotifySendEmailSuccessResponseFromEmail(): String = "voter-card-application-support@valtech.com"
+
+fun aNotifySendLetterSuccessResponsePostage(): String = "second"

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/dto/SendNotificationRequestDtoBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/dto/SendNotificationRequestDtoBuilder.kt
@@ -2,12 +2,14 @@ package uk.gov.dluhc.notificationsapi.testsupport.testdata.dto
 
 import uk.gov.dluhc.notificationsapi.dto.LanguageDto
 import uk.gov.dluhc.notificationsapi.dto.NotificationChannel
+import uk.gov.dluhc.notificationsapi.dto.NotificationDestinationDto
 import uk.gov.dluhc.notificationsapi.dto.NotificationType
 import uk.gov.dluhc.notificationsapi.dto.SendNotificationRequestDto
 import uk.gov.dluhc.notificationsapi.dto.SourceType
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aGssCode
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aNotificationChannel
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aNotificationType
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.aPostalAddress
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aRequestor
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aSourceReference
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aSourceType
@@ -18,7 +20,9 @@ fun buildSendNotificationRequestDto(
     requestor: String = aRequestor(),
     sourceType: SourceType = aSourceType(),
     sourceReference: String = aSourceReference(),
-    emailAddress: String = anEmailAddress(),
+    toAddress: NotificationDestinationDto = NotificationDestinationDto(
+        emailAddress = anEmailAddress(), postalAddress = aPostalAddress()
+    ),
     notificationType: NotificationType = aNotificationType(),
     channel: NotificationChannel = aNotificationChannel(),
     language: LanguageDto = LanguageDto.ENGLISH,
@@ -28,7 +32,7 @@ fun buildSendNotificationRequestDto(
         requestor = requestor,
         sourceType = sourceType,
         sourceReference = sourceReference,
-        emailAddress = emailAddress,
+        toAddress = toAddress,
         notificationType = notificationType,
         channel = channel,
         language = language,

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/messaging/models/SendNotifyResubmissionMessageBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/messaging/models/SendNotifyResubmissionMessageBuilder.kt
@@ -1,14 +1,17 @@
 package uk.gov.dluhc.notificationsapi.testsupport.testdata.messaging.models
 
+import uk.gov.dluhc.notificationsapi.messaging.models.Address
 import uk.gov.dluhc.notificationsapi.messaging.models.IdDocumentPersonalisation
 import uk.gov.dluhc.notificationsapi.messaging.models.Language
 import uk.gov.dluhc.notificationsapi.messaging.models.MessageAddress
+import uk.gov.dluhc.notificationsapi.messaging.models.MessageAddressPostalAddress
 import uk.gov.dluhc.notificationsapi.messaging.models.MessageType
 import uk.gov.dluhc.notificationsapi.messaging.models.NotificationChannel
 import uk.gov.dluhc.notificationsapi.messaging.models.PhotoPersonalisation
 import uk.gov.dluhc.notificationsapi.messaging.models.SendNotifyIdDocumentResubmissionMessage
 import uk.gov.dluhc.notificationsapi.messaging.models.SendNotifyPhotoResubmissionMessage
 import uk.gov.dluhc.notificationsapi.messaging.models.SourceType
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.DataFaker.Companion.faker
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aGssCode
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aRequestor
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aSourceReference
@@ -23,7 +26,7 @@ fun buildSendNotifyPhotoResubmissionMessage(
     requestor: String = aRequestor(),
     messageType: MessageType = MessageType.PHOTO_MINUS_RESUBMISSION,
     personalisation: PhotoPersonalisation = buildPhotoPersonalisationMessage(),
-    toAddress: MessageAddress = MessageAddress(emailAddress = anEmailAddress()),
+    toAddress: MessageAddress = aMessageAddress(),
 ): SendNotifyPhotoResubmissionMessage =
     SendNotifyPhotoResubmissionMessage(
         channel = channel,
@@ -46,7 +49,7 @@ fun buildSendNotifyIdDocumentResubmissionMessage(
     requestor: String = aRequestor(),
     messageType: MessageType = MessageType.PHOTO_MINUS_RESUBMISSION,
     personalisation: IdDocumentPersonalisation = buildIdDocumentPersonalisationMessage(),
-    toAddress: MessageAddress = MessageAddress(emailAddress = anEmailAddress()),
+    toAddress: MessageAddress = aMessageAddress(),
 ): SendNotifyIdDocumentResubmissionMessage =
     SendNotifyIdDocumentResubmissionMessage(
         channel = channel,
@@ -58,6 +61,35 @@ fun buildSendNotifyIdDocumentResubmissionMessage(
         messageType = messageType,
         personalisation = personalisation,
         toAddress = toAddress,
+    )
+
+fun aMessageAddress(
+    emailAddress: String? = anEmailAddress(),
+    postalAddress: MessageAddressPostalAddress? = aMessageAddressPostalAddress()
+) = MessageAddress(
+    emailAddress = emailAddress,
+    postalAddress = postalAddress
+)
+
+fun aMessageAddressPostalAddress(
+    addressee: String = faker.name().firstName(),
+    property: String = faker.address().streetName(),
+    street: String = faker.address().buildingNumber(),
+    town: String? = faker.address().streetName(),
+    area: String? = faker.address().city(),
+    locality: String? = faker.address().state(),
+    postcode: String = faker.address().postcode(),
+): MessageAddressPostalAddress =
+    MessageAddressPostalAddress(
+        addressee = addressee,
+        address = Address(
+            property = property,
+            street = street,
+            town = town,
+            area = area,
+            locality = locality,
+            postcode = postcode
+        ),
     )
 
 fun aSendNotifyPhotoResubmissionMessage() = buildSendNotifyPhotoResubmissionMessage()


### PR DESCRIPTION
Adds sending the existing comms types of Photo and Document resubmission by the new Latter channel.  Notable changes are the mapping from the SQS `toAddress` postal address details to the Notify API personalisation properties and integration with the Notify API sendLetter method.  