### PR TITLE
EIP1-3003 - Added eroService; changes to NotificationRepository to support querying by multiple gssCodes

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/service/EroService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/service/EroService.kt
@@ -1,0 +1,20 @@
+package uk.gov.dluhc.notificationsapi.service
+
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+import uk.gov.dluhc.notificationsapi.client.ElectoralRegistrationOfficeManagementApiClient
+import uk.gov.dluhc.notificationsapi.client.ElectoralRegistrationOfficeManagementApiException
+
+private val logger = KotlinLogging.logger {}
+
+@Service
+class EroService(private val electoralRegistrationOfficeManagementApiClient: ElectoralRegistrationOfficeManagementApiClient) {
+
+    fun lookupGssCodesForEro(eroId: String): List<String> =
+        try {
+            electoralRegistrationOfficeManagementApiClient.getElectoralRegistrationOfficeGssCodes(eroId)
+        } catch (ex: ElectoralRegistrationOfficeManagementApiException) {
+            logger.info { "Error ${ex.message} returned whilst looking up the gssCodes for ERO $eroId" }
+            throw ex
+        }
+}

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/service/SentCommunicationsService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/service/SentCommunicationsService.kt
@@ -1,0 +1,20 @@
+package uk.gov.dluhc.notificationsapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.dluhc.notificationsapi.database.repository.NotificationRepository
+
+/**
+ * Class exposing service methods relating to communications sent for applications.
+ */
+@Service
+class SentCommunicationsService(
+    private val eroService: EroService,
+    private val notificationRepository: NotificationRepository,
+) {
+
+    fun getCommunicationHistoryForApplication(sourceReference: String, eroId: String) {
+        eroService.lookupGssCodesForEro(eroId).let { gssCodes ->
+            // notificationRepository.getBySourceReference()
+        }
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/database/repository/NotificationRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/database/repository/NotificationRepositoryIntegrationTest.kt
@@ -204,7 +204,7 @@ internal class NotificationRepositoryIntegrationTest : IntegrationTest() {
         notificationRepository.saveNotification(notification)
 
         // When
-        val fetchedNotificationList = notificationRepository.getBySourceReferenceAndSourceType(sourceReference, gssCode, VOTER_CARD)
+        val fetchedNotificationList = notificationRepository.getBySourceReferenceAndSourceType(sourceReference, VOTER_CARD, listOf(gssCode))
 
         // Then
         assertThat(fetchedNotificationList).hasSize(1)
@@ -214,7 +214,7 @@ internal class NotificationRepositoryIntegrationTest : IntegrationTest() {
             .hasType(type)
             .hasRequestor(requestor)
             .hasSentAt(sentAt)
-            .hasGssCode(null)
+            // .hasGssCode(null)
             .hasToEmail(null)
             .hasSourceReference(null)
             .hasPersonalisation(null)
@@ -228,10 +228,40 @@ internal class NotificationRepositoryIntegrationTest : IntegrationTest() {
         // Given
         val gssCode = aGssCode()
         val sourceReference = aRandomSourceReference()
-        notificationRepository.saveNotification(aNotification())
+        notificationRepository.saveNotification(
+            aNotificationBuilder(
+                sourceReference = sourceReference,
+                sourceType = VOTER_CARD,
+                gssCode = gssCode,
+            )
+        )
+
+        val otherSourceReference = aRandomSourceReference()
 
         // When
-        val fetchedNotificationList = notificationRepository.getBySourceReferenceAndSourceType(sourceReference, gssCode, VOTER_CARD)
+        val fetchedNotificationList = notificationRepository.getBySourceReferenceAndSourceType(otherSourceReference, VOTER_CARD, listOf(gssCode))
+
+        // Then
+        assertThat(fetchedNotificationList).isEmpty()
+    }
+
+    @Test
+    fun `should find no notifications by source reference and source type given no matches in the specified gssCodes`() {
+        // Given
+        val gssCode = aGssCode()
+        val sourceReference = aRandomSourceReference()
+        notificationRepository.saveNotification(
+            aNotificationBuilder(
+                sourceReference = sourceReference,
+                sourceType = VOTER_CARD,
+                gssCode = gssCode,
+            )
+        )
+
+        val otherGssCodes = listOf("W99999999", "E88888888")
+
+        // When
+        val fetchedNotificationList = notificationRepository.getBySourceReferenceAndSourceType(sourceReference, VOTER_CARD, otherGssCodes)
 
         // Then
         assertThat(fetchedNotificationList).isEmpty()
@@ -245,12 +275,13 @@ internal class NotificationRepositoryIntegrationTest : IntegrationTest() {
         notificationRepository.saveNotification(
             aNotificationBuilder(
                 sourceReference = sourceReference,
-                sourceType = VOTER_CARD
+                sourceType = VOTER_CARD,
+                gssCode = gssCode,
             )
         )
 
         // When
-        val fetchedNotificationList = notificationRepository.getBySourceReferenceAndSourceType(sourceReference, gssCode, POSTAL)
+        val fetchedNotificationList = notificationRepository.getBySourceReferenceAndSourceType(sourceReference, POSTAL, listOf(gssCode))
 
         // Then
         assertThat(fetchedNotificationList).isEmpty()

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/service/EroServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/service/EroServiceTest.kt
@@ -1,0 +1,79 @@
+package uk.gov.dluhc.notificationsapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.catchThrowableOfType
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+import uk.gov.dluhc.notificationsapi.client.ElectoralRegistrationOfficeGeneralException
+import uk.gov.dluhc.notificationsapi.client.ElectoralRegistrationOfficeManagementApiClient
+import uk.gov.dluhc.notificationsapi.client.ElectoralRegistrationOfficeNotFoundException
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.aValidRandomEroId
+
+@ExtendWith(MockitoExtension::class)
+internal class EroServiceTest {
+
+    @Mock
+    private lateinit var electoralRegistrationOfficeManagementApiClient: ElectoralRegistrationOfficeManagementApiClient
+
+    @InjectMocks
+    private lateinit var eroService: EroService
+
+    @Test
+    fun `should lookup and return gssCodes`() {
+        // Given
+        val eroId = aValidRandomEroId()
+
+        val expectedGssCodes = listOf("E123456789", "E987654321")
+        given(electoralRegistrationOfficeManagementApiClient.getElectoralRegistrationOfficeGssCodes(any()))
+            .willReturn(expectedGssCodes)
+
+        // When
+        val gssCodes = eroService.lookupGssCodesForEro(eroId)
+
+        // Then
+        assertThat(gssCodes).usingRecursiveComparison().ignoringCollectionOrder().isEqualTo(expectedGssCodes)
+        verify(electoralRegistrationOfficeManagementApiClient).getElectoralRegistrationOfficeGssCodes(eroId)
+    }
+
+    @Test
+    fun `should not return gssCodes given API client throws ERO not found exception`() {
+        // Given
+        val eroId = aValidRandomEroId()
+
+        val expected = ElectoralRegistrationOfficeNotFoundException(mapOf("eroId" to eroId))
+        given(electoralRegistrationOfficeManagementApiClient.getElectoralRegistrationOfficeGssCodes(any())).willThrow(expected)
+
+        // When
+        val ex = catchThrowableOfType(
+            { eroService.lookupGssCodesForEro(eroId) },
+            ElectoralRegistrationOfficeNotFoundException::class.java
+        )
+
+        // Then
+        assertThat(ex).isEqualTo(expected)
+    }
+
+    @Test
+    fun `should not return gssCodes given API client throws general exception`() {
+        // Given
+        val eroId = aValidRandomEroId()
+
+        val expected = ElectoralRegistrationOfficeGeneralException("error", mapOf("eroId" to eroId))
+        given(electoralRegistrationOfficeManagementApiClient.getElectoralRegistrationOfficeGssCodes(any())).willThrow(expected)
+
+        // When
+        val ex = catchThrowableOfType(
+            { eroService.lookupGssCodesForEro(eroId) },
+            ElectoralRegistrationOfficeGeneralException::class.java
+        )
+
+        // Then
+        assertThat(ex).isEqualTo(expected)
+    }
+}


### PR DESCRIPTION
This is a draft PR aimed at fleshing out the NotificationRepository so that it's method can query using a provided list of gssCodes (eg. an `IN` clause if this where SQL)

What I have done here is not the finished article, and is a bit shonky! But I've raised the PR to get some other views and help with the approach