### PR TITLE
EIP1-3402 - Data retention - avoid using gssCode when removing notifications

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/dto/RemoveNotificationsDto.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/dto/RemoveNotificationsDto.kt
@@ -1,7 +1,6 @@
 package uk.gov.dluhc.notificationsapi.dto
 
 data class RemoveNotificationsDto(
-    val gssCode: String,
     val sourceType: SourceType,
     val sourceReference: String
 )

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/RemoveApplicationNotificationsMessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/RemoveApplicationNotificationsMessageListener.kt
@@ -23,8 +23,7 @@ class RemoveApplicationNotificationsMessageListener(
             logger.info {
                 "RemoveApplicationNotificationsMessage received with " +
                     "sourceType: $sourceType and " +
-                    "sourceReference: $sourceReference and " +
-                    "gssCode: $gssCode"
+                    "sourceReference: $sourceReference"
             }
             removeNotificationsService.remove(removeNotificationsMapper.toRemoveNotificationsDto(this))
         }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/service/RemoveNotificationsService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/service/RemoveNotificationsService.kt
@@ -20,13 +20,13 @@ class RemoveNotificationsService(
     /**
      * Removes any notifications belonging to an application.
      *
-     * @param removeNotificationsDto DTO containing the application's ID and GSS code.
+     * @param removeNotificationsDto DTO containing the application's ID.
      */
     fun remove(removeNotificationsDto: RemoveNotificationsDto) {
         try {
             with(removeNotificationsDto) {
                 val sourceType = sourceTypeMapper.toSourceTypeEntity(this.sourceType)
-                notificationRepository.removeBySourceReference(sourceReference, sourceType, gssCode)
+                notificationRepository.removeBySourceReference(sourceReference, sourceType)
             }
         } catch (ex: SdkException) {
             logger.error { "Error attempting to remove notifications: $ex" }

--- a/src/main/resources/openapi/sqs/Notifications-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/Notifications-sqs-messaging.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Notifications SQS Message Types
-  version: '1.5.0'
+  version: '1.5.1'
   description: |-
     Notifications SQS Message Types
     
@@ -125,13 +125,9 @@ components:
         sourceReference:
           type: string
           description: Reference of the application in the corresponding source system that the message relates to
-        gssCode:
-          type: string
-          description: GSS code of the ERO the application belongs to
       required:
         - sourceType
         - sourceReference
-        - gssCode
 
     IdDocumentPersonalisation:
       title: IdDocumentPersonalisation

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/database/repository/NotificationRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/database/repository/NotificationRepositoryIntegrationTest.kt
@@ -20,6 +20,7 @@ import uk.gov.dluhc.notificationsapi.testsupport.testdata.aRandomSourceReference
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aRequestor
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aSourceReference
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.anEmailAddress
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.anotherGssCode
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.database.entity.aNotificationBuilder
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.database.entity.aNotifyDetails
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.database.entity.anEntityChannel
@@ -125,11 +126,11 @@ internal class NotificationRepositoryIntegrationTest : IntegrationTest() {
                 notifyDetails = notifyDetails,
                 sentAt = sentAt
             )
-            deleteNotifications(notificationRepository.getBySourceReference(sourceReference, sourceType, listOf(gssCode)))
+            deleteNotifications(notificationRepository.getBySourceReferenceAndGssCode(sourceReference, sourceType, listOf(gssCode)))
             notificationRepository.saveNotification(notification)
 
             // When
-            val fetchedNotificationList = notificationRepository.getBySourceReference(sourceReference, sourceType, listOf(gssCode))
+            val fetchedNotificationList = notificationRepository.getBySourceReferenceAndGssCode(sourceReference, sourceType, listOf(gssCode))
 
             // Then
             assertThat(fetchedNotificationList).hasSize(1)
@@ -165,7 +166,7 @@ internal class NotificationRepositoryIntegrationTest : IntegrationTest() {
             val otherSourceReference = aRandomSourceReference()
 
             // When
-            val fetchedNotificationList = notificationRepository.getBySourceReference(otherSourceReference, sourceType, listOf(gssCode))
+            val fetchedNotificationList = notificationRepository.getBySourceReferenceAndGssCode(otherSourceReference, sourceType, listOf(gssCode))
 
             // Then
             assertThat(fetchedNotificationList).isEmpty()
@@ -178,22 +179,30 @@ internal class NotificationRepositoryIntegrationTest : IntegrationTest() {
         @Test
         fun `should remove notifications by source reference`() {
             // Given
-            val gssCode = aGssCode()
+            val gssCode1 = aGssCode()
+            val gssCode2 = anotherGssCode()
             val sourceReference = aRandomSourceReference()
             val sourceType = anEntitySourceType()
             notificationRepository.saveNotification(
                 aNotificationBuilder(
-                    gssCode = gssCode,
+                    gssCode = gssCode1,
+                    sourceReference = sourceReference,
+                    sourceType = sourceType,
+                )
+            )
+            notificationRepository.saveNotification(
+                aNotificationBuilder(
+                    gssCode = gssCode2,
                     sourceReference = sourceReference,
                     sourceType = sourceType,
                 )
             )
 
             // When
-            notificationRepository.removeBySourceReference(sourceReference, sourceType, gssCode)
+            notificationRepository.removeBySourceReference(sourceReference, sourceType)
 
             // Then
-            val fetchedNotificationList = notificationRepository.getBySourceReference(sourceReference, sourceType, listOf(gssCode))
+            val fetchedNotificationList = notificationRepository.getBySourceReferenceAndGssCode(sourceReference, sourceType, listOf(gssCode1, gssCode2))
             assertThat(fetchedNotificationList).isEmpty()
         }
     }
@@ -229,7 +238,7 @@ internal class NotificationRepositoryIntegrationTest : IntegrationTest() {
                 sentAt = sentAt
             )
             deleteNotifications(
-                notificationRepository.getBySourceReference(
+                notificationRepository.getBySourceReferenceAndGssCode(
                     sourceReference,
                     VOTER_CARD,
                     listOf(gssCode)

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/RemoveApplicationNotificationsMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/RemoveApplicationNotificationsMessageListenerIntegrationTest.kt
@@ -32,7 +32,6 @@ internal class RemoveApplicationNotificationsMessageListenerIntegrationTest : In
             )
         }
         val sqsMessage = buildRemoveApplicationNotificationsMessage(
-            gssCode = gssCode,
             sourceReference = sourceReference
         )
 
@@ -42,7 +41,7 @@ internal class RemoveApplicationNotificationsMessageListenerIntegrationTest : In
         // Then
         val stopWatch = StopWatch.createStarted()
         await.atMost(3, TimeUnit.SECONDS).untilAsserted {
-            assertThat(notificationRepository.getBySourceReference(sourceReference, VOTER_CARD, listOf(gssCode))).isEmpty()
+            assertThat(notificationRepository.getBySourceReferenceAndGssCode(sourceReference, VOTER_CARD, listOf(gssCode))).isEmpty()
             stopWatch.stop()
             logger.info("Completed assertions in $stopWatch for 2 removed notifications")
         }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyIdDocumentResubmissionMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyIdDocumentResubmissionMessageListenerIntegrationTest.kt
@@ -38,7 +38,7 @@ internal class SendNotifyIdDocumentResubmissionMessageListenerIntegrationTest : 
             sourceType = sourceType,
             sourceReference = sourceReference
         )
-        deleteNotifications(notificationRepository.getBySourceReference(sourceReference, VOTER_CARD, listOf(gssCode)))
+        deleteNotifications(notificationRepository.getBySourceReferenceAndGssCode(sourceReference, VOTER_CARD, listOf(gssCode)))
         wireMockService.stubNotifySendEmailResponse(NotifySendEmailSuccessResponse())
 
         // When
@@ -48,7 +48,7 @@ internal class SendNotifyIdDocumentResubmissionMessageListenerIntegrationTest : 
         val stopWatch = StopWatch.createStarted()
         await.atMost(3, TimeUnit.SECONDS).untilAsserted {
             wireMockService.verifyNotifySendEmailCalled()
-            val actualEntity = notificationRepository.getBySourceReference(sourceReference, VOTER_CARD, listOf(gssCode))
+            val actualEntity = notificationRepository.getBySourceReferenceAndGssCode(sourceReference, VOTER_CARD, listOf(gssCode))
             Assertions.assertThat(actualEntity).hasSize(1)
             stopWatch.stop()
             logger.info("completed assertions in $stopWatch for language $language")
@@ -71,7 +71,7 @@ internal class SendNotifyIdDocumentResubmissionMessageListenerIntegrationTest : 
             sourceType = sourceType,
             sourceReference = sourceReference
         )
-        deleteNotifications(notificationRepository.getBySourceReference(sourceReference, VOTER_CARD, listOf(gssCode)))
+        deleteNotifications(notificationRepository.getBySourceReferenceAndGssCode(sourceReference, VOTER_CARD, listOf(gssCode)))
         wireMockService.stubNotifySendLetterResponse(NotifySendLetterSuccessResponse())
 
         // When
@@ -81,7 +81,7 @@ internal class SendNotifyIdDocumentResubmissionMessageListenerIntegrationTest : 
         val stopWatch = StopWatch.createStarted()
         await.atMost(3000, TimeUnit.SECONDS).untilAsserted {
             wireMockService.verifyNotifySendLetterCalled()
-            val actualEntity = notificationRepository.getBySourceReference(sourceReference, VOTER_CARD, listOf(gssCode))
+            val actualEntity = notificationRepository.getBySourceReferenceAndGssCode(sourceReference, VOTER_CARD, listOf(gssCode))
             Assertions.assertThat(actualEntity).hasSize(1)
             stopWatch.stop()
             logger.info("completed assertions in $stopWatch for language $language")

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyPhotoResubmissionMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyPhotoResubmissionMessageListenerIntegrationTest.kt
@@ -38,7 +38,7 @@ internal class SendNotifyPhotoResubmissionMessageListenerIntegrationTest : Integ
             sourceType = sourceType,
             sourceReference = sourceReference
         )
-        deleteNotifications(notificationRepository.getBySourceReference(sourceReference, VOTER_CARD, listOf(gssCode)))
+        deleteNotifications(notificationRepository.getBySourceReferenceAndGssCode(sourceReference, VOTER_CARD, listOf(gssCode)))
         wireMockService.stubNotifySendEmailResponse(NotifySendEmailSuccessResponse())
 
         // When
@@ -48,7 +48,7 @@ internal class SendNotifyPhotoResubmissionMessageListenerIntegrationTest : Integ
         val stopWatch = StopWatch.createStarted()
         await.atMost(3, TimeUnit.SECONDS).untilAsserted {
             wireMockService.verifyNotifySendEmailCalled()
-            val actualEntity = notificationRepository.getBySourceReference(sourceReference, VOTER_CARD, listOf(gssCode))
+            val actualEntity = notificationRepository.getBySourceReferenceAndGssCode(sourceReference, VOTER_CARD, listOf(gssCode))
             assertThat(actualEntity).hasSize(1)
             stopWatch.stop()
             logger.info("completed assertions in $stopWatch for language $language")
@@ -71,7 +71,7 @@ internal class SendNotifyPhotoResubmissionMessageListenerIntegrationTest : Integ
             sourceType = sourceType,
             sourceReference = sourceReference
         )
-        deleteNotifications(notificationRepository.getBySourceReference(sourceReference, VOTER_CARD, listOf(gssCode)))
+        deleteNotifications(notificationRepository.getBySourceReferenceAndGssCode(sourceReference, VOTER_CARD, listOf(gssCode)))
         wireMockService.stubNotifySendLetterResponse(NotifySendLetterSuccessResponse())
 
         // When
@@ -81,7 +81,7 @@ internal class SendNotifyPhotoResubmissionMessageListenerIntegrationTest : Integ
         val stopWatch = StopWatch.createStarted()
         await.atMost(3, TimeUnit.SECONDS).untilAsserted {
             wireMockService.verifyNotifySendLetterCalled()
-            val actualEntity = notificationRepository.getBySourceReference(sourceReference, VOTER_CARD, listOf(gssCode))
+            val actualEntity = notificationRepository.getBySourceReferenceAndGssCode(sourceReference, VOTER_CARD, listOf(gssCode))
             assertThat(actualEntity).hasSize(1)
             stopWatch.stop()
             logger.info("completed assertions in $stopWatch for language $language")

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/RemoveNotificationsMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/RemoveNotificationsMapperTest.kt
@@ -12,7 +12,6 @@ import org.mockito.kotlin.verify
 import uk.gov.dluhc.notificationsapi.dto.SourceType
 import uk.gov.dluhc.notificationsapi.mapper.SourceTypeMapper
 import uk.gov.dluhc.notificationsapi.messaging.models.RemoveApplicationNotificationsMessage
-import uk.gov.dluhc.notificationsapi.testsupport.testdata.aGssCode
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aSourceReference
 import uk.gov.dluhc.notificationsapi.messaging.models.SourceType as SqsSourceType
 
@@ -27,10 +26,9 @@ internal class RemoveNotificationsMapperTest {
 
     @Test
     fun `should map SQS RemoveApplicationNotificationsMessage to RemoveNotificationsDto`() {
-        val gssCode = aGssCode()
         val sourceReference = aSourceReference()
         val sourceType = SqsSourceType.VOTER_MINUS_CARD
-        val request = RemoveApplicationNotificationsMessage(gssCode = gssCode, sourceReference = sourceReference, sourceType = sourceType)
+        val request = RemoveApplicationNotificationsMessage(sourceReference = sourceReference, sourceType = sourceType)
         val expectedSourceType = SourceType.VOTER_CARD
         given(sourceTypeMapper.toSourceTypeDto(any())).willReturn(expectedSourceType)
 
@@ -38,7 +36,6 @@ internal class RemoveNotificationsMapperTest {
 
         assertThat(removeNotificationsDto.sourceType).isEqualTo(expectedSourceType)
         assertThat(removeNotificationsDto.sourceReference).isEqualTo(sourceReference)
-        assertThat(removeNotificationsDto.gssCode).isEqualTo(gssCode)
         verify(sourceTypeMapper).toSourceTypeDto(SqsSourceType.VOTER_MINUS_CARD)
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/service/RemoveNotificationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/service/RemoveNotificationsServiceTest.kt
@@ -40,7 +40,7 @@ internal class RemoveNotificationsServiceTest {
         removeNotificationsService.remove(removeNotificationsDto)
 
         // Then
-        verify(notificationRepository).removeBySourceReference(removeNotificationsDto.sourceReference, VOTER_CARD, removeNotificationsDto.gssCode)
+        verify(notificationRepository).removeBySourceReference(removeNotificationsDto.sourceReference, VOTER_CARD)
         verify(sourceTypeMapper).toSourceTypeEntity(removeNotificationsDto.sourceType)
     }
 
@@ -49,7 +49,7 @@ internal class RemoveNotificationsServiceTest {
         // Given
         val removeNotificationsDto = aRemoveNotificationsDto()
         given(sourceTypeMapper.toSourceTypeEntity(any())).willReturn(VOTER_CARD)
-        given(notificationRepository.removeBySourceReference(any(), any(), any())).willThrow(SdkClientException.create("SDK exception"))
+        given(notificationRepository.removeBySourceReference(any(), any())).willThrow(SdkClientException.create("SDK exception"))
 
         // When
         val ex = catchThrowableOfType(

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/CommonDataBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/CommonDataBuilder.kt
@@ -17,6 +17,8 @@ fun aRequestor() = "user-id"
 
 fun aGssCode() = "E99999999"
 
+fun anotherGssCode() = "E88888888"
+
 fun aSourceReference() = "fea5d37b-5c4a-445c-b428-7dc799be1d8e"
 
 fun aRandomSourceReference() = UUID.randomUUID().toString()

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/dto/RemoveNotificationsDtoBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/dto/RemoveNotificationsDtoBuilder.kt
@@ -2,17 +2,14 @@ package uk.gov.dluhc.notificationsapi.testsupport.testdata.dto
 
 import uk.gov.dluhc.notificationsapi.dto.RemoveNotificationsDto
 import uk.gov.dluhc.notificationsapi.dto.SourceType
-import uk.gov.dluhc.notificationsapi.testsupport.testdata.aGssCode
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aSourceReference
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aSourceType
 
 fun buildRemoveNotificationsDto(
-    gssCode: String = aGssCode(),
     sourceType: SourceType = aSourceType(),
     sourceReference: String = aSourceReference()
 ): RemoveNotificationsDto =
     RemoveNotificationsDto(
-        gssCode = gssCode,
         sourceType = sourceType,
         sourceReference = sourceReference
     )

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/messaging/models/RemoveApplicationNotificationsMessageBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/messaging/models/RemoveApplicationNotificationsMessageBuilder.kt
@@ -2,16 +2,13 @@ package uk.gov.dluhc.notificationsapi.testsupport.testdata.messaging.models
 
 import uk.gov.dluhc.notificationsapi.messaging.models.RemoveApplicationNotificationsMessage
 import uk.gov.dluhc.notificationsapi.messaging.models.SourceType
-import uk.gov.dluhc.notificationsapi.testsupport.testdata.aGssCode
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aSourceReference
 
 fun buildRemoveApplicationNotificationsMessage(
     sourceType: SourceType = SourceType.VOTER_MINUS_CARD,
-    sourceReference: String = aSourceReference(),
-    gssCode: String = aGssCode()
+    sourceReference: String = aSourceReference()
 ): RemoveApplicationNotificationsMessage =
     RemoveApplicationNotificationsMessage(
         sourceType = sourceType,
-        sourceReference = sourceReference,
-        gssCode = gssCode
+        sourceReference = sourceReference
     )


### PR DESCRIPTION
### Background ###
A small number of EROs have more than one `gssCode`, meaning the user has to select the right one when creating an application. In the scenario where this value is then changed (e.g. because the user selected the wrong one), any corresponding records in the notifications-api will have the old `gssCode`.

### Solution ###
This PR makes a simple change to ignore the `gssCode` when removing application data, since a combination of the `sourceType` (e.g. `VOTER_CARD`) and `applicationId` will almost certainly be unique.

