### PR TITLE
EIP1-2457 Send application approved email SQS message

### DIFF
--- a/src/main/resources/openapi/sqs/Notifications-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/Notifications-sqs-messaging.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Notifications SQS Message Types
-  version: '1.5.1'
+  version: '1.6.0'
   description: |-
     Notifications SQS Message Types
     


### PR DESCRIPTION
Adds new queue and message type for sending application approved email comms.
Moved the `channel` out of the basic `SendNotifyMessage` as the application approved only allows `email` as a channel (and the application rejected must be sent by `letter`)

![image](https://user-images.githubusercontent.com/54864568/215750997-ee11a98d-c4d7-4a09-a98a-c12a685eb700.png)
```
{
  "language": "en",
  "sourceType": "voter-card",
  "sourceReference": "string",
  "gssCode": "string",
  "requestor": "string",
  "toAddress": {
    "emailAddress": "user@example.com",
    "postalAddress": {
      "addressee": "string",
      "address": {
        "street": "Charles Lane",
        "property": "string",
        "locality": "string",
        "town": "London",
        "area": "string",
        "postcode": "PE3 6SB"
      }
    },
    "smsNumber": "string"
  },
  "messageType": "application-received",
  "personalisation": {
    "applicationReference": "A3JSZC4CRH",
    "firstName": "Fred",
    "eroContactDetails": {
      "localAuthorityName": "City of Sunderland",
      "website": "https://ero-address.com",
      "phone": "01234 567890",
      "email": "fred.blogs@some-domain.co.uk",
      "address": {
        "street": "Charles Lane",
        "property": "string",
        "locality": "string",
        "town": "London",
        "area": "string",
        "postcode": "PE3 6SB"
      }
    }
  }
}

```