### PR TITLE
EIP1-4399: EIP1-4437: create offline comms - controller

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/rest/ControllerSecurityConstants.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/rest/ControllerSecurityConstants.kt
@@ -1,0 +1,13 @@
+package uk.gov.dluhc.notificationsapi.rest
+
+const val HAS_ERO_VC_ANONYMOUS_ADMIN_AUTHORITY = """
+        hasAnyAuthority("ero-vc-anonymous-admin-".concat(#eroId))
+    """
+const val HAS_ERO_VC_ADMIN_AUTHORITY = """
+        hasAnyAuthority("ero-vc-admin-".concat(#eroId))
+    """
+const val HAS_ERO_VC_ADMIN_OR_VC_VIEWER_AUTHORITY = """
+        hasAnyAuthority("ero-vc-admin-".concat(#eroId), 
+                        "ero-vc-viewer-".concat(#eroId)
+                        )
+        """

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/rest/SentCommunicationsController.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/rest/SentCommunicationsController.kt
@@ -1,37 +1,35 @@
 package uk.gov.dluhc.notificationsapi.rest
 
+import org.springframework.http.HttpStatus
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.dluhc.notificationsapi.dto.SourceType
 import uk.gov.dluhc.notificationsapi.mapper.NotificationSummaryMapper
 import uk.gov.dluhc.notificationsapi.models.CommunicationsHistoryResponse
+import uk.gov.dluhc.notificationsapi.models.CreateOfflineCommunicationConfirmationRequest
 import uk.gov.dluhc.notificationsapi.service.SentNotificationsService
+import javax.validation.Valid
 
 /**
  * REST Controller exposing APIs relating to communications that have been sent.
  */
 @RestController
 @CrossOrigin
+@RequestMapping("/eros/{eroId}/communications")
 class SentCommunicationsController(
     private val sentNotificationsService: SentNotificationsService,
     private val notificationSummaryMapper: NotificationSummaryMapper,
 ) {
 
-    companion object {
-        const val ERO_VC_ADMIN_GROUP_PREFIX = "ero-vc-admin-"
-    }
-
-    @GetMapping("/eros/{eroId}/communications/applications/{applicationId}")
-    @PreAuthorize(
-        """
-        hasAnyAuthority(
-            T(uk.gov.dluhc.notificationsapi.rest.SentCommunicationsController).ERO_VC_ADMIN_GROUP_PREFIX.concat(#eroId)
-        )
-        """
-    )
+    @GetMapping("applications/{applicationId}")
+    @PreAuthorize(HAS_ERO_VC_ADMIN_AUTHORITY)
     fun getCommunicationHistoryByApplicationId(
         @PathVariable eroId: String,
         @PathVariable applicationId: String,
@@ -45,4 +43,15 @@ class SentCommunicationsController(
         }.let {
             CommunicationsHistoryResponse(communications = it)
         }
+
+    @PostMapping("anonymous-applications/{applicationId}")
+    @PreAuthorize(HAS_ERO_VC_ANONYMOUS_ADMIN_AUTHORITY)
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun createOfflineCommunicationConfirmation(
+        @PathVariable eroId: String,
+        @PathVariable applicationId: String,
+        @Valid @RequestBody request: CreateOfflineCommunicationConfirmationRequest,
+    ) {
+        TODO("EIP1-4399 confirm offline communications has been sent")
+    }
 }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/config/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/config/IntegrationTest.kt
@@ -21,6 +21,8 @@ import software.amazon.awssdk.services.dynamodb.model.ScanRequest
 import uk.gov.dluhc.notificationsapi.client.GovNotifyApiClient
 import uk.gov.dluhc.notificationsapi.database.repository.NotificationRepository
 import uk.gov.dluhc.notificationsapi.testsupport.WiremockService
+import uk.gov.dluhc.notificationsapi.testsupport.getDifferentRandomEroId
+import uk.gov.dluhc.notificationsapi.testsupport.getRandomEroId
 import uk.gov.service.notify.NotificationClient
 
 /**
@@ -89,6 +91,8 @@ internal abstract class IntegrationTest {
     protected lateinit var objectMapper: ObjectMapper
 
     companion object {
+        val ERO_ID = getRandomEroId()
+        val OTHER_ERO_ID = getDifferentRandomEroId(ERO_ID)
         val localStackContainer = LocalStackContainerConfiguration.getInstance()
     }
 

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/CreateOfflineCommunicationConfirmationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/CreateOfflineCommunicationConfirmationIntegrationTest.kt
@@ -1,0 +1,102 @@
+package uk.gov.dluhc.notificationsapi.rest
+
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import reactor.core.publisher.Mono
+import uk.gov.dluhc.notificationsapi.config.IntegrationTest
+import uk.gov.dluhc.notificationsapi.models.CreateOfflineCommunicationConfirmationRequest
+import uk.gov.dluhc.notificationsapi.models.OfflineCommunicationChannel
+import uk.gov.dluhc.notificationsapi.models.OfflineCommunicationReason
+import uk.gov.dluhc.notificationsapi.testsupport.bearerToken
+import uk.gov.dluhc.notificationsapi.testsupport.getRandomGssCode
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.UNAUTHORIZED_BEARER_TOKEN
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.getBearerTokenWithAllRolesExcept
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.getVCAnonymousAdminBearerToken
+
+internal class CreateOfflineCommunicationConfirmationIntegrationTest : IntegrationTest() {
+
+    companion object {
+        private const val URI_TEMPLATE = "/eros/{ERO_ID}/communications/anonymous-applications/{APPLICATION_ID}"
+        private const val APPLICATION_ID = "7762ccac7c056046b75d4aa3"
+    }
+
+    @Test
+    fun `should return forbidden given no bearer token`() {
+        webTestClient.post()
+            .uri(URI_TEMPLATE, ERO_ID, APPLICATION_ID)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(
+                buildBody(),
+                CreateOfflineCommunicationConfirmationRequest::class.java
+            )
+            .exchange()
+            .expectStatus()
+            .isForbidden
+    }
+
+    @Test
+    fun `should return unauthorized given user with invalid bearer token`() {
+        webTestClient.post()
+            .uri(URI_TEMPLATE, ERO_ID, APPLICATION_ID)
+            .bearerToken(UNAUTHORIZED_BEARER_TOKEN)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(
+                buildBody(),
+                CreateOfflineCommunicationConfirmationRequest::class.java
+            )
+            .exchange()
+            .expectStatus()
+            .isUnauthorized
+    }
+
+    @Test
+    fun `should return forbidden given user with valid bearer token belonging to a different group`() {
+        wireMockService.stubCognitoJwtIssuerResponse()
+
+        webTestClient.post()
+            .uri(URI_TEMPLATE, ERO_ID, APPLICATION_ID)
+            // the group ero-vc-anonymous-admin-$ERO_ID is required to be successful
+            .bearerToken(
+                getBearerTokenWithAllRolesExcept(eroId = ERO_ID, excludedRoles = listOf("ero-vc-anonymous-admin"))
+            )
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(
+                buildBody(),
+                CreateOfflineCommunicationConfirmationRequest::class.java
+            )
+            .exchange()
+            .expectStatus()
+            .isForbidden
+    }
+
+    @Test
+    fun `should return forbidden given user with valid bearer token belonging to a different ero`() {
+        wireMockService.stubCognitoJwtIssuerResponse()
+
+        webTestClient.post()
+            .uri(URI_TEMPLATE, ERO_ID, APPLICATION_ID)
+            // the group ero-vc-anonymous-admin-$ERO_ID is required to be successful
+            .bearerToken(getVCAnonymousAdminBearerToken(OTHER_ERO_ID))
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(
+                buildBody(),
+                CreateOfflineCommunicationConfirmationRequest::class.java
+            )
+            .exchange()
+            .expectStatus()
+            .isForbidden
+    }
+
+    private fun buildBody(
+        gssCode: String = getRandomGssCode(),
+        reason: OfflineCommunicationReason = OfflineCommunicationReason.APPLICATION_MINUS_REJECTED,
+        channel: OfflineCommunicationChannel = OfflineCommunicationChannel.LETTER,
+    ) =
+        Mono.just(
+            CreateOfflineCommunicationConfirmationRequest(
+                gssCode = gssCode,
+                reason = reason,
+                channel = channel,
+            )
+        )
+}

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/JwtAccessTokenBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/JwtAccessTokenBuilder.kt
@@ -2,6 +2,8 @@ package uk.gov.dluhc.notificationsapi.testsupport.testdata
 
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.SignatureAlgorithm
+import uk.gov.dluhc.eromanagementapi.models.EroGroup
+import uk.gov.dluhc.notificationsapi.config.IntegrationTest.Companion.ERO_ID
 import uk.gov.dluhc.notificationsapi.testsupport.RsaKeyPair
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -17,6 +19,23 @@ fun getBearerToken(
     groups: List<String> = listOf("ero-$eroId", "ero-vc-admin-$eroId")
 ): String =
     "Bearer ${buildAccessToken(eroId, email, groups)}"
+
+fun getBearerTokenWithAllRolesExcept(
+    eroId: String = aValidRandomEroId(),
+    email: String = "an-ero-user@$eroId.gov.uk",
+    excludedRoles: List<String> = listOf("ero-vc-admin")
+): String {
+    val excludedGroups = excludedRoles.map { "$it-$eroId" }.toSet()
+    val allGroupEroNames = EroGroup.values().map { it.value }.map { "ero-$it-$eroId" }.toSet()
+    val requiredGroups = allGroupEroNames - excludedGroups
+    return getBearerToken(eroId, email, requiredGroups.toList())
+}
+
+fun getVCAnonymousAdminBearerToken(eroId: String = ERO_ID, userName: String = "an-ero-user1@$eroId.gov.uk") =
+    getBearerToken(groups = listOf("ero-$eroId", "ero-vc-anonymous-admin-$eroId"), email = userName)
+
+fun getVCAdminBearerToken(eroId: String = ERO_ID, userName: String = "an-ero-user2@$eroId.gov.uk") =
+    getBearerToken(groups = listOf("ero-$eroId", "ero-vc-admin-$eroId"), email = userName)
 
 fun buildAccessToken(
     eroId: String = aValidRandomEroId(),


### PR DESCRIPTION
This PR adds the usual API security int-tests for POST:/eros/{ERO_ID}/communications/anonymous-applications/{APPLICATION_ID}