### PR TITLE
EIP1-4400: EIP1-4590: fetch offline comms - controller

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/rest/CommunicationConfirmationsController.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/rest/CommunicationConfirmationsController.kt
@@ -1,0 +1,56 @@
+package uk.gov.dluhc.notificationsapi.rest
+
+import org.springframework.http.HttpStatus
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.CrossOrigin
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.dluhc.notificationsapi.mapper.CommunicationConfirmationMapper
+import uk.gov.dluhc.notificationsapi.models.CommunicationConfirmationHistoryResponse
+import uk.gov.dluhc.notificationsapi.models.CreateOfflineCommunicationConfirmationRequest
+import uk.gov.dluhc.notificationsapi.service.CommunicationConfirmationsService
+import javax.validation.Valid
+
+/**
+ * REST Controller exposing APIs relating to offline communication confirmations.
+ */
+@RestController
+@CrossOrigin
+@RequestMapping("/eros/{eroId}/communications")
+class CommunicationConfirmationsController(
+    private val communicationConfirmationsService: CommunicationConfirmationsService,
+    private val communicationConfirmationMapper: CommunicationConfirmationMapper,
+) {
+
+    @PostMapping("anonymous-applications/{applicationId}")
+    @PreAuthorize(HAS_ERO_VC_ANONYMOUS_ADMIN_AUTHORITY)
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun createOfflineCommunicationConfirmation(
+        @PathVariable eroId: String,
+        @PathVariable applicationId: String,
+        @Valid @RequestBody request: CreateOfflineCommunicationConfirmationRequest,
+        authentication: Authentication,
+    ) {
+        val dto = communicationConfirmationMapper.fromApiToDto(
+            eroId = eroId,
+            sourceReference = applicationId,
+            requestor = authentication.name,
+            request = request,
+        )
+        communicationConfirmationsService.saveCommunicationConfirmation(dto)
+    }
+
+    @GetMapping("anonymous-applications/{applicationId}")
+    @PreAuthorize(HAS_ERO_VC_ANONYMOUS_ADMIN_AUTHORITY)
+    fun getOfflineCommunicationConfirmations(
+        @PathVariable eroId: String,
+        @PathVariable applicationId: String,
+    ): CommunicationConfirmationHistoryResponse =
+        TODO("EIP1-4400 - AEDs - retrieve list of offline communications - API")
+}

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/rest/SentCommunicationsController.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/rest/SentCommunicationsController.kt
@@ -1,24 +1,15 @@
 package uk.gov.dluhc.notificationsapi.rest
 
-import org.springframework.http.HttpStatus
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.dluhc.notificationsapi.dto.SourceType
-import uk.gov.dluhc.notificationsapi.mapper.CommunicationConfirmationMapper
 import uk.gov.dluhc.notificationsapi.mapper.NotificationSummaryMapper
 import uk.gov.dluhc.notificationsapi.models.CommunicationsHistoryResponse
-import uk.gov.dluhc.notificationsapi.models.CreateOfflineCommunicationConfirmationRequest
-import uk.gov.dluhc.notificationsapi.service.CommunicationConfirmationsService
 import uk.gov.dluhc.notificationsapi.service.SentNotificationsService
-import javax.validation.Valid
 
 /**
  * REST Controller exposing APIs relating to communications that have been sent.
@@ -28,9 +19,7 @@ import javax.validation.Valid
 @RequestMapping("/eros/{eroId}/communications")
 class SentCommunicationsController(
     private val sentNotificationsService: SentNotificationsService,
-    private val communicationConfirmationsService: CommunicationConfirmationsService,
     private val notificationSummaryMapper: NotificationSummaryMapper,
-    private val communicationConfirmationMapper: CommunicationConfirmationMapper,
 ) {
 
     @GetMapping("applications/{applicationId}")
@@ -48,22 +37,4 @@ class SentCommunicationsController(
         }.let {
             CommunicationsHistoryResponse(communications = it)
         }
-
-    @PostMapping("anonymous-applications/{applicationId}")
-    @PreAuthorize(HAS_ERO_VC_ANONYMOUS_ADMIN_AUTHORITY)
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    fun createOfflineCommunicationConfirmation(
-        @PathVariable eroId: String,
-        @PathVariable applicationId: String,
-        @Valid @RequestBody request: CreateOfflineCommunicationConfirmationRequest,
-        authentication: Authentication,
-    ) {
-        val dto = communicationConfirmationMapper.fromApiToDto(
-            eroId = eroId,
-            sourceReference = applicationId,
-            requestor = authentication.name,
-            request = request,
-        )
-        communicationConfirmationsService.saveCommunicationConfirmation(dto)
-    }
 }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GetCommunicationConfirmationHistoryByApplicationIdIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GetCommunicationConfirmationHistoryByApplicationIdIntegrationTest.kt
@@ -1,0 +1,67 @@
+package uk.gov.dluhc.notificationsapi.rest
+
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import uk.gov.dluhc.notificationsapi.config.IntegrationTest
+import uk.gov.dluhc.notificationsapi.testsupport.bearerToken
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.UNAUTHORIZED_BEARER_TOKEN
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.getBearerTokenWithAllRolesExcept
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.getVCAnonymousAdminBearerToken
+
+internal class GetCommunicationConfirmationHistoryByApplicationIdIntegrationTest : IntegrationTest() {
+
+    companion object {
+        private const val URI_TEMPLATE = "/eros/{ERO_ID}/communications/anonymous-applications/{APPLICATION_ID}"
+        private const val APPLICATION_ID = "7762ccac7c056046b75d4aa3"
+    }
+
+    @Test
+    fun `should return unauthorized given no bearer token`() {
+        webTestClient.get()
+            .uri(URI_TEMPLATE, ERO_ID, APPLICATION_ID)
+            .exchange()
+            .expectStatus()
+            .isUnauthorized
+    }
+
+    @Test
+    fun `should return unauthorized given user with invalid bearer token`() {
+        webTestClient.get()
+            .uri(URI_TEMPLATE, ERO_ID, APPLICATION_ID)
+            .bearerToken(UNAUTHORIZED_BEARER_TOKEN)
+            .contentType(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isUnauthorized
+    }
+
+    @Test
+    fun `should return forbidden given user with valid bearer token belonging to a different group`() {
+        wireMockService.stubCognitoJwtIssuerResponse()
+
+        webTestClient.get()
+            .uri(URI_TEMPLATE, ERO_ID, APPLICATION_ID)
+            // the group ero-vc-anonymous-admin-$ERO_ID is required to be successful
+            .bearerToken(
+                getBearerTokenWithAllRolesExcept(eroId = ERO_ID, excludedRoles = listOf("ero-vc-anonymous-admin"))
+            )
+            .contentType(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isForbidden
+    }
+
+    @Test
+    fun `should return forbidden given user with valid bearer token belonging to a different ero`() {
+        wireMockService.stubCognitoJwtIssuerResponse()
+
+        webTestClient.get()
+            .uri(URI_TEMPLATE, ERO_ID, APPLICATION_ID)
+            // the group ero-vc-anonymous-admin-$ERO_ID is required to be successful
+            .bearerToken(getVCAnonymousAdminBearerToken(OTHER_ERO_ID))
+            .contentType(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isForbidden
+    }
+}


### PR DESCRIPTION
This PR adds the controller and security int-tests for GET: /eros/{eroId}/communications/anonymous-applications/{applicationId}