### PR TITLE
EIP1-4400: EIP1-4591: fetch offline comms - service

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -116,6 +116,7 @@ tasks.withType<KotlinCompile> {
 tasks.withType<Test> {
     dependsOn(tasks.withType<GenerateTask>())
     useJUnitPlatform()
+    jvmArgs("--add-opens", "java.base/java.time=ALL-UNNAMED")
 }
 
 tasks.withType<GenerateTask> {

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/dto/CommunicationConfirmationDto.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/dto/CommunicationConfirmationDto.kt
@@ -1,9 +1,11 @@
 package uk.gov.dluhc.notificationsapi.dto
 
 import java.time.LocalDateTime
+import java.util.UUID
 
 data class CommunicationConfirmationDto(
-    val eroId: String,
+    val id: UUID? = null,
+    val eroId: String? = null,
     val sourceReference: String,
     val sourceType: SourceType,
     val gssCode: String,

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/CommunicationConfirmationChannelMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/CommunicationConfirmationChannelMapper.kt
@@ -1,14 +1,18 @@
 package uk.gov.dluhc.notificationsapi.mapper
 
 import org.mapstruct.Mapper
+import uk.gov.dluhc.notificationsapi.database.entity.CommunicationConfirmationChannel
 import uk.gov.dluhc.notificationsapi.dto.CommunicationConfirmationChannelDto
-import uk.gov.dluhc.notificationsapi.database.entity.CommunicationConfirmationChannel as OfflineCommunicationChannelEntity
-import uk.gov.dluhc.notificationsapi.models.OfflineCommunicationChannel as OfflineCommunicationChannelApi
+import uk.gov.dluhc.notificationsapi.models.OfflineCommunicationChannel
 
 @Mapper
 interface CommunicationConfirmationChannelMapper {
 
-    fun fromApiToDto(apiChannelEnum: OfflineCommunicationChannelApi): CommunicationConfirmationChannelDto
+    fun fromApiToDto(apiChannelEnum: OfflineCommunicationChannel): CommunicationConfirmationChannelDto
 
-    fun fromDtoToEntity(dtoEnum: CommunicationConfirmationChannelDto): OfflineCommunicationChannelEntity
+    fun fromDtoToApi(dtoChannelEnum: CommunicationConfirmationChannelDto): OfflineCommunicationChannel
+
+    fun fromEntityToDto(entityChannelEnum: CommunicationConfirmationChannel): CommunicationConfirmationChannelDto
+
+    fun fromDtoToEntity(dtoChannelEnum: CommunicationConfirmationChannelDto): CommunicationConfirmationChannel
 }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/CommunicationConfirmationMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/CommunicationConfirmationMapper.kt
@@ -1,28 +1,50 @@
 package uk.gov.dluhc.notificationsapi.mapper
 
+import org.mapstruct.InheritInverseConfiguration
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping
+import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.dluhc.notificationsapi.database.entity.CommunicationConfirmation
 import uk.gov.dluhc.notificationsapi.dto.CommunicationConfirmationDto
+import uk.gov.dluhc.notificationsapi.models.CommunicationConfirmationHistoryEntry
 import uk.gov.dluhc.notificationsapi.models.CreateOfflineCommunicationConfirmationRequest
+import java.time.Clock
 import java.time.LocalDateTime
 import java.util.UUID
 
 @Mapper(
-    uses = [CommunicationConfirmationReasonMapper::class, CommunicationConfirmationChannelMapper::class, SourceTypeMapper::class],
+    uses = [
+        CommunicationConfirmationReasonMapper::class,
+        CommunicationConfirmationChannelMapper::class,
+        SourceTypeMapper::class,
+        DateTimeMapper::class,
+    ],
     imports = [UUID::class, LocalDateTime::class],
 )
-interface CommunicationConfirmationMapper {
+abstract class CommunicationConfirmationMapper {
+
+    @Autowired
+    protected lateinit var clock: Clock
 
     @Mapping(target = "sourceType", constant = "ANONYMOUS_ELECTOR_DOCUMENT")
-    @Mapping(target = "sentAt", expression = "java( LocalDateTime.now() )")
-    fun fromApiToDto(
+    @Mapping(target = "sentAt", expression = "java( LocalDateTime.now(clock) )")
+    abstract fun fromApiToDto(
         eroId: String,
         sourceReference: String,
         requestor: String,
         request: CreateOfflineCommunicationConfirmationRequest
     ): CommunicationConfirmationDto
 
+    @Mapping(target = "timestamp", source = "sentAt")
+    abstract fun fromDtoToApi(dto: CommunicationConfirmationDto): CommunicationConfirmationHistoryEntry
+
+    abstract fun fromDtosToApis(dtos: List<CommunicationConfirmationDto>): List<CommunicationConfirmationHistoryEntry>
+
     @Mapping(target = "id", expression = "java(UUID.randomUUID())")
-    fun fromDtoToEntity(dto: CommunicationConfirmationDto): CommunicationConfirmation
+    abstract fun fromDtoToEntity(dto: CommunicationConfirmationDto): CommunicationConfirmation
+
+    @InheritInverseConfiguration
+    abstract fun fromEntityToDto(entity: CommunicationConfirmation): CommunicationConfirmationDto
+
+    abstract fun fromEntitiesToDtos(entities: List<CommunicationConfirmation>): List<CommunicationConfirmationDto>
 }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/CommunicationConfirmationReasonMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/CommunicationConfirmationReasonMapper.kt
@@ -1,5 +1,6 @@
 package uk.gov.dluhc.notificationsapi.mapper
 
+import org.mapstruct.InheritInverseConfiguration
 import org.mapstruct.Mapper
 import org.mapstruct.ValueMapping
 import uk.gov.dluhc.notificationsapi.dto.CommunicationConfirmationReasonDto
@@ -14,5 +15,10 @@ interface CommunicationConfirmationReasonMapper {
     @ValueMapping(target = "DOCUMENT_REJECTED", source = "DOCUMENT_MINUS_REJECTED")
     fun fromApiToDto(apiReasonEnum: OfflineCommunicationReasonApi): CommunicationConfirmationReasonDto
 
+    @InheritInverseConfiguration
+    fun fromDtoToApi(dtoReasonEnum: CommunicationConfirmationReasonDto): OfflineCommunicationReasonApi
+
     fun fromDtoToEntity(dtoEnum: CommunicationConfirmationReasonDto): OfflineCommunicationReasonEntity
+
+    fun fromEntityToDto(entityEnum: OfflineCommunicationReasonEntity): CommunicationConfirmationReasonDto
 }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/DateTimeMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/DateTimeMapper.kt
@@ -1,0 +1,10 @@
+package uk.gov.dluhc.notificationsapi.mapper
+
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+import java.time.ZoneOffset.UTC
+
+@Component
+class DateTimeMapper {
+    fun toUtcOffset(localDateTime: LocalDateTime?) = localDateTime?.atOffset(UTC)
+}

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/rest/CommunicationConfirmationsController.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/rest/CommunicationConfirmationsController.kt
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.dluhc.notificationsapi.dto.SourceType
 import uk.gov.dluhc.notificationsapi.mapper.CommunicationConfirmationMapper
 import uk.gov.dluhc.notificationsapi.models.CommunicationConfirmationHistoryResponse
 import uk.gov.dluhc.notificationsapi.models.CreateOfflineCommunicationConfirmationRequest
@@ -51,6 +52,14 @@ class CommunicationConfirmationsController(
     fun getOfflineCommunicationConfirmations(
         @PathVariable eroId: String,
         @PathVariable applicationId: String,
-    ): CommunicationConfirmationHistoryResponse =
-        TODO("EIP1-4400 - AEDs - retrieve list of offline communications - API")
+    ) =
+        communicationConfirmationsService.getCommunicationConfirmationsForApplication(
+            sourceReference = applicationId,
+            eroId = eroId,
+            SourceType.ANONYMOUS_ELECTOR_DOCUMENT,
+        ).let { dtos ->
+            CommunicationConfirmationHistoryResponse(
+                communicationConfirmations = communicationConfirmationMapper.fromDtosToApis(dtos)
+            )
+        }
 }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/service/CommunicationConfirmationsService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/service/CommunicationConfirmationsService.kt
@@ -2,9 +2,12 @@ package uk.gov.dluhc.notificationsapi.service
 
 import mu.KotlinLogging
 import org.springframework.stereotype.Service
+import uk.gov.dluhc.notificationsapi.database.entity.CommunicationConfirmation
 import uk.gov.dluhc.notificationsapi.database.repository.CommunicationConfirmationRepository
 import uk.gov.dluhc.notificationsapi.dto.CommunicationConfirmationDto
+import uk.gov.dluhc.notificationsapi.dto.SourceType
 import uk.gov.dluhc.notificationsapi.mapper.CommunicationConfirmationMapper
+import uk.gov.dluhc.notificationsapi.mapper.SourceTypeMapper
 
 private val logger = KotlinLogging.logger {}
 
@@ -16,13 +19,36 @@ class CommunicationConfirmationsService(
     private val eroService: EroService,
     private val communicationConfirmationRepository: CommunicationConfirmationRepository,
     private val communicationConfirmationMapper: CommunicationConfirmationMapper,
+    private val sourceTypeMapper: SourceTypeMapper,
 ) {
     fun saveCommunicationConfirmation(dto: CommunicationConfirmationDto) =
         with(dto) {
             logger.debug { "Saving communication confirmation for $sourceType application $sourceReference" }
 
-            eroService.validateGssCodeAssociatedWithEro(eroId = eroId, gssCode = gssCode)
+            eroService.validateGssCodeAssociatedWithEro(eroId = eroId!!, gssCode = gssCode)
             val entity = communicationConfirmationMapper.fromDtoToEntity(dto)
             communicationConfirmationRepository.saveCommunicationConfirmation(entity)
         }
+
+    /**
+     * Returns a list of [CommunicationConfirmationDto]s for the application identified by the specified
+     * sourceReference, ERO ID and sourceType.
+     */
+    fun getCommunicationConfirmationsForApplication(
+        sourceReference: String,
+        eroId: String,
+        sourceType: SourceType,
+    ): List<CommunicationConfirmationDto> {
+        val gssCodesForEro = eroService.lookupGssCodesForEro(eroId)
+        val sortedCommunicationConfirmations: List<CommunicationConfirmation> =
+            communicationConfirmationRepository.getBySourceReferenceAndTypeAndGssCodes(
+                sourceReference = sourceReference,
+                sourceType = sourceTypeMapper.fromDtoToEntity(sourceType),
+                gssCodes = gssCodesForEro,
+            ).sortedByDescending { it.sentAt }
+
+        logger.debug { "Returning ${sortedCommunicationConfirmations.size} CommunicationConfirmations for $sourceType application $sourceReference" }
+
+        return communicationConfirmationMapper.fromEntitiesToDtos(sortedCommunicationConfirmations)
+    }
 }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/CommunicationConfirmationChannelMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/CommunicationConfirmationChannelMapperTest.kt
@@ -18,14 +18,14 @@ class CommunicationConfirmationChannelMapperTest {
             "TELEPHONE, TELEPHONE",
         ]
     )
-    fun fromApiToDto(apiEnum: OfflineCommunicationChannelApi, expectedDto: CommunicationConfirmationChannelDto) {
+    fun `from api to dto`(apiEnum: OfflineCommunicationChannelApi, dtoEnum: CommunicationConfirmationChannelDto) {
         // Given
 
         // When
-        val actual = mapper.fromApiToDto(apiEnum)
+        val actualFromApiToDto = mapper.fromApiToDto(apiEnum)
 
         // Then
-        assertThat(actual).isEqualTo(expectedDto)
+        assertThat(actualFromApiToDto).isEqualTo(dtoEnum)
     }
 
     @ParameterizedTest
@@ -36,13 +36,49 @@ class CommunicationConfirmationChannelMapperTest {
             "TELEPHONE, TELEPHONE",
         ]
     )
-    fun fromDtoToEntity(dto: CommunicationConfirmationChannelDto, expectedEntity: OfflineCommunicationChannelEntity) {
+    fun `from dto to api`(dtoEnum: CommunicationConfirmationChannelDto, apiEnum: OfflineCommunicationChannelApi) {
         // Given
 
         // When
-        val actual = mapper.fromDtoToEntity(dto)
+        val actualFromDtoToApi = mapper.fromDtoToApi(dtoEnum)
 
         // Then
-        assertThat(actual).isEqualTo(expectedEntity)
+        assertThat(actualFromDtoToApi).isEqualTo(apiEnum)
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            "EMAIL, EMAIL",
+            "LETTER, LETTER",
+            "TELEPHONE, TELEPHONE",
+        ]
+    )
+    fun `from entity to dto`(entityEnum: OfflineCommunicationChannelEntity, dtoEnum: CommunicationConfirmationChannelDto) {
+        // Given
+
+        // When
+        val actualFromEntityToDto = mapper.fromEntityToDto(entityEnum)
+
+        // Then
+        assertThat(actualFromEntityToDto).isEqualTo(dtoEnum)
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            "EMAIL, EMAIL",
+            "LETTER, LETTER",
+            "TELEPHONE, TELEPHONE",
+        ]
+    )
+    fun `from dto to entity`(dtoEnum: CommunicationConfirmationChannelDto, entityEnum: OfflineCommunicationChannelEntity) {
+        // Given
+
+        // When
+        val actualFromDtoToEntity = mapper.fromDtoToEntity(dtoEnum)
+
+        // Then
+        assertThat(actualFromDtoToEntity).isEqualTo(entityEnum)
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/CommunicationConfirmationMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/CommunicationConfirmationMapperTest.kt
@@ -1,25 +1,39 @@
 package uk.gov.dluhc.notificationsapi.mapper
 
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.within
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.Spy
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
 import uk.gov.dluhc.notificationsapi.database.entity.CommunicationConfirmation
+import uk.gov.dluhc.notificationsapi.database.entity.CommunicationConfirmationChannel
+import uk.gov.dluhc.notificationsapi.database.entity.CommunicationConfirmationReason
+import uk.gov.dluhc.notificationsapi.database.entity.SourceType
 import uk.gov.dluhc.notificationsapi.dto.CommunicationConfirmationChannelDto
 import uk.gov.dluhc.notificationsapi.dto.CommunicationConfirmationDto
 import uk.gov.dluhc.notificationsapi.dto.CommunicationConfirmationReasonDto
-import uk.gov.dluhc.notificationsapi.models.CreateOfflineCommunicationConfirmationRequest
+import uk.gov.dluhc.notificationsapi.models.OfflineCommunicationChannel
+import uk.gov.dluhc.notificationsapi.models.OfflineCommunicationReason
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aGssCode
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aLocalDateTime
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aSourceReference
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aValidRandomEroId
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.anEmailAddress
-import java.time.temporal.ChronoUnit.SECONDS
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aCommunicationConfirmationDtoBuilder
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.models.aCommunicationConfirmationHistoryEntryBuilder
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.models.aCreateOfflineCommunicationConfirmationRequestBuilder
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
 import uk.gov.dluhc.notificationsapi.database.entity.CommunicationConfirmationChannel as OfflineCommunicationChannelEntity
 import uk.gov.dluhc.notificationsapi.database.entity.CommunicationConfirmationReason as OfflineCommunicationReasonEntity
 import uk.gov.dluhc.notificationsapi.database.entity.SourceType as SourceTypeEntity
@@ -29,6 +43,11 @@ import uk.gov.dluhc.notificationsapi.models.OfflineCommunicationReason as Offlin
 
 @ExtendWith(MockitoExtension::class)
 class CommunicationConfirmationMapperTest {
+    companion object {
+        private val FIXED_TIME = Instant.parse("2022-10-18T11:22:32.123Z")
+        private val FIXED_CLOCK = Clock.fixed(FIXED_TIME, ZoneOffset.UTC)
+    }
+
     @InjectMocks
     private lateinit var mapper: CommunicationConfirmationMapperImpl
 
@@ -41,9 +60,112 @@ class CommunicationConfirmationMapperTest {
     @Mock
     private lateinit var communicationConfirmationChannelMapper: CommunicationConfirmationChannelMapper
 
+    @Mock
+    private lateinit var dateTimeMapper: DateTimeMapper
+
+    @Spy
+    private val clock: Clock = FIXED_CLOCK
+
+    @Test
+    fun `should map from api to dto`() {
+        // Given
+        val eroId: String = aValidRandomEroId()
+        val sourceReference: String = aSourceReference()
+        val requestor: String = anEmailAddress()
+        val gssCode: String = aGssCode()
+        val reason = OfflineCommunicationReasonApi.PHOTO_MINUS_REJECTED
+        val channel = OfflineCommunicationChannelApi.LETTER
+        val fixedLocalDateTime = LocalDateTime.now(FIXED_CLOCK)
+
+        val request = aCreateOfflineCommunicationConfirmationRequestBuilder(
+            gssCode = gssCode,
+            reason = reason,
+            channel = channel,
+        )
+
+        val expectedDto = aCommunicationConfirmationDtoBuilder(
+            id = null,
+            eroId = eroId,
+            sourceReference = sourceReference,
+            sourceType = SourceTypeDto.ANONYMOUS_ELECTOR_DOCUMENT,
+            requestor = requestor,
+            gssCode = gssCode,
+            reason = CommunicationConfirmationReasonDto.PHOTO_REJECTED,
+            channel = CommunicationConfirmationChannelDto.LETTER,
+            sentAt = fixedLocalDateTime,
+        )
+
+        given(communicationConfirmationReasonMapper.fromApiToDto(any()))
+            .willReturn(CommunicationConfirmationReasonDto.PHOTO_REJECTED)
+        given(communicationConfirmationChannelMapper.fromApiToDto(any()))
+            .willReturn(CommunicationConfirmationChannelDto.LETTER)
+
+        // When
+        val actualDto: CommunicationConfirmationDto = mapper.fromApiToDto(eroId, sourceReference, requestor, request)
+
+        // Then
+        assertThat(actualDto).isEqualTo(expectedDto)
+        verify(communicationConfirmationReasonMapper).fromApiToDto(reason)
+        verify(communicationConfirmationChannelMapper).fromApiToDto(channel)
+    }
+
+    @Test
+    fun `should map from dtos to apis`() {
+        // Given
+        val id = UUID.randomUUID()
+        val eroId: String = aValidRandomEroId()
+        val sourceReference: String = aSourceReference()
+        val requestor: String = anEmailAddress()
+        val gssCode: String = aGssCode()
+        val reason = CommunicationConfirmationReasonDto.PHOTO_REJECTED
+        val channel = CommunicationConfirmationChannelDto.EMAIL
+
+        val oneMinAgoLocal = LocalDateTime.now().minusMinutes(1)
+        val oneMinAgoOffset = OffsetDateTime.of(oneMinAgoLocal, ZoneOffset.UTC)
+
+        val dto1 = aCommunicationConfirmationDtoBuilder(
+            id = id,
+            eroId = eroId,
+            sourceReference = sourceReference,
+            sourceType = SourceTypeDto.ANONYMOUS_ELECTOR_DOCUMENT,
+            requestor = requestor,
+            gssCode = gssCode,
+            reason = reason,
+            channel = channel,
+            sentAt = oneMinAgoLocal,
+        )
+
+        val expectedApi = listOf(
+            aCommunicationConfirmationHistoryEntryBuilder(
+                id = id,
+                gssCode = gssCode,
+                reason = OfflineCommunicationReason.PHOTO_MINUS_REJECTED,
+                channel = OfflineCommunicationChannel.EMAIL,
+                requestor = requestor,
+                timestamp = oneMinAgoOffset,
+            ),
+        )
+
+        given(communicationConfirmationReasonMapper.fromDtoToApi(CommunicationConfirmationReasonDto.PHOTO_REJECTED))
+            .willReturn(OfflineCommunicationReasonApi.PHOTO_MINUS_REJECTED)
+        given(communicationConfirmationChannelMapper.fromDtoToApi(CommunicationConfirmationChannelDto.EMAIL))
+            .willReturn(OfflineCommunicationChannelApi.EMAIL)
+        given(dateTimeMapper.toUtcOffset(oneMinAgoLocal)).willReturn(oneMinAgoOffset)
+
+        // When
+        val actualApiEntry = mapper.fromDtosToApis(listOf(dto1))
+
+        // Then
+        assertThat(actualApiEntry).isEqualTo(expectedApi)
+        verify(communicationConfirmationReasonMapper).fromDtoToApi(reason)
+        verify(communicationConfirmationChannelMapper).fromDtoToApi(channel)
+        verify(dateTimeMapper).toUtcOffset(oneMinAgoLocal)
+    }
+
     @Test
     fun `should map from dto to entity`() {
         // Given
+        val id = UUID.randomUUID()
         val eroId: String = aValidRandomEroId()
         val sourceReference: String = aSourceReference()
         val sourceType: SourceTypeDto = SourceTypeDto.ANONYMOUS_ELECTOR_DOCUMENT
@@ -64,6 +186,17 @@ class CommunicationConfirmationMapperTest {
             sentAt = sentAt,
         )
 
+        val expectedEntity = CommunicationConfirmation(
+            id = id,
+            gssCode = gssCode,
+            sourceReference = sourceReference,
+            sourceType = SourceType.ANONYMOUS_ELECTOR_DOCUMENT,
+            reason = CommunicationConfirmationReason.APPLICATION_REJECTED,
+            channel = CommunicationConfirmationChannel.LETTER,
+            requestor = requestor,
+            sentAt = sentAt,
+        )
+
         given(sourceTypeMapper.fromDtoToEntity(any()))
             .willReturn(SourceTypeEntity.ANONYMOUS_ELECTOR_DOCUMENT)
         given(communicationConfirmationReasonMapper.fromDtoToEntity(any()))
@@ -72,53 +205,68 @@ class CommunicationConfirmationMapperTest {
             .willReturn(OfflineCommunicationChannelEntity.LETTER)
 
         // When
-        val actualEntity: CommunicationConfirmation = mapper.fromDtoToEntity(dto)
+        val actualEntity = Mockito.mockStatic(UUID::class.java).use { mockedUuid ->
+            mockedUuid.`when`<UUID> { UUID.randomUUID() }.thenReturn(id)
+            mapper.fromDtoToEntity(dto)
+        }
 
         // Then
-        assertThat(actualEntity.id).isNotNull
-        assertThat(actualEntity.gssCode).isEqualTo(gssCode)
-        assertThat(actualEntity.sourceReference).isEqualTo(sourceReference)
-        assertThat(actualEntity.sourceType).isEqualTo(SourceTypeEntity.ANONYMOUS_ELECTOR_DOCUMENT)
-        assertThat(actualEntity.reason).isEqualTo(OfflineCommunicationReasonEntity.APPLICATION_REJECTED)
-        assertThat(actualEntity.channel).isEqualTo(OfflineCommunicationChannelEntity.LETTER)
-        assertThat(actualEntity.requestor).isEqualTo(requestor)
-        assertThat(actualEntity.sentAt).isEqualTo(sentAt)
+        assertThat(actualEntity).isEqualTo(expectedEntity)
+        verify(sourceTypeMapper).fromDtoToEntity(sourceType)
+        verify(communicationConfirmationReasonMapper).fromDtoToEntity(reason)
+        verify(communicationConfirmationChannelMapper).fromDtoToEntity(channel)
     }
 
     @Test
-    fun `should map from api to dto`() {
+    fun `should map from entities to dtos`() {
         // Given
-        val eroId: String = aValidRandomEroId()
+        val id: UUID = UUID.randomUUID()
         val sourceReference: String = aSourceReference()
-        val requestor: String = anEmailAddress()
-
         val gssCode: String = aGssCode()
-        val reason = OfflineCommunicationReasonApi.APPLICATION_MINUS_REJECTED
-        val channel = OfflineCommunicationChannelApi.LETTER
+        val sourceType: SourceType = SourceType.ANONYMOUS_ELECTOR_DOCUMENT
+        val reason: CommunicationConfirmationReason = CommunicationConfirmationReason.APPLICATION_REJECTED
+        val channel: CommunicationConfirmationChannel = CommunicationConfirmationChannel.LETTER
+        val requestor: String = anEmailAddress()
+        val sentAt = aLocalDateTime()
 
-        val request = CreateOfflineCommunicationConfirmationRequest(
+        val entity = CommunicationConfirmation(
+            id = id,
             gssCode = gssCode,
+            sourceReference = sourceReference,
+            sourceType = sourceType,
             reason = reason,
             channel = channel,
+            requestor = requestor,
+            sentAt = sentAt,
         )
 
-        given(communicationConfirmationReasonMapper.fromApiToDto(any()))
+        val expectedDto = listOf(
+            CommunicationConfirmationDto(
+                id = id,
+                sourceReference = sourceReference,
+                gssCode = gssCode,
+                sourceType = SourceTypeDto.ANONYMOUS_ELECTOR_DOCUMENT,
+                reason = CommunicationConfirmationReasonDto.APPLICATION_REJECTED,
+                channel = CommunicationConfirmationChannelDto.LETTER,
+                requestor = requestor,
+                sentAt = sentAt,
+            )
+        )
+
+        given(sourceTypeMapper.fromEntityToDto(any()))
+            .willReturn(SourceTypeDto.ANONYMOUS_ELECTOR_DOCUMENT)
+        given(communicationConfirmationReasonMapper.fromEntityToDto(any()))
             .willReturn(CommunicationConfirmationReasonDto.APPLICATION_REJECTED)
-        given(communicationConfirmationChannelMapper.fromApiToDto(any()))
+        given(communicationConfirmationChannelMapper.fromEntityToDto(any()))
             .willReturn(CommunicationConfirmationChannelDto.LETTER)
 
         // When
-        val actualDto: CommunicationConfirmationDto =
-            mapper.fromApiToDto(eroId, sourceReference, requestor, request)
+        val actualDto = mapper.fromEntitiesToDtos(listOf(entity))
 
         // Then
-        assertThat(actualDto.eroId).isEqualTo(eroId)
-        assertThat(actualDto.sourceReference).isEqualTo(sourceReference)
-        assertThat(actualDto.sourceType).isEqualTo(SourceTypeDto.ANONYMOUS_ELECTOR_DOCUMENT)
-        assertThat(actualDto.gssCode).isEqualTo(gssCode)
-        assertThat(actualDto.reason).isEqualTo(CommunicationConfirmationReasonDto.APPLICATION_REJECTED)
-        assertThat(actualDto.channel).isEqualTo(CommunicationConfirmationChannelDto.LETTER)
-        assertThat(actualDto.requestor).isEqualTo(requestor)
-        assertThat(actualDto.sentAt).isCloseToUtcNow(within(1, SECONDS))
+        assertThat(actualDto).isEqualTo(expectedDto)
+        verify(sourceTypeMapper).fromEntityToDto(SourceType.ANONYMOUS_ELECTOR_DOCUMENT)
+        verify(communicationConfirmationReasonMapper).fromEntityToDto(CommunicationConfirmationReason.APPLICATION_REJECTED)
+        verify(communicationConfirmationChannelMapper).fromEntityToDto(CommunicationConfirmationChannel.LETTER)
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/CommunicationConfirmationReasonMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/CommunicationConfirmationReasonMapperTest.kt
@@ -18,14 +18,32 @@ class CommunicationConfirmationReasonMapperTest {
             "DOCUMENT_MINUS_REJECTED, DOCUMENT_REJECTED",
         ]
     )
-    fun fromApiToDto(apiEnum: OfflineCommunicationReasonApi, expectedDto: CommunicationConfirmationReasonDto) {
+    fun `from api to dto`(apiEnum: OfflineCommunicationReasonApi, dtoEnum: CommunicationConfirmationReasonDto) {
         // Given
 
         // When
-        val actual = mapper.fromApiToDto(apiEnum)
+        val actualFromApiToDto = mapper.fromApiToDto(apiEnum)
 
         // Then
-        assertThat(actual).isEqualTo(expectedDto)
+        assertThat(actualFromApiToDto).isEqualTo(dtoEnum)
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            "APPLICATION_REJECTED, APPLICATION_MINUS_REJECTED",
+            "PHOTO_REJECTED, PHOTO_MINUS_REJECTED",
+            "DOCUMENT_REJECTED, DOCUMENT_MINUS_REJECTED",
+        ]
+    )
+    fun `from dto to api`(dtoEnum: CommunicationConfirmationReasonDto, apiEnum: OfflineCommunicationReasonApi) {
+        // Given
+
+        // When
+        val actualFromDtoToApi = mapper.fromDtoToApi(dtoEnum)
+
+        // Then
+        assertThat(actualFromDtoToApi).isEqualTo(apiEnum)
     }
 
     @ParameterizedTest
@@ -36,13 +54,31 @@ class CommunicationConfirmationReasonMapperTest {
             "DOCUMENT_REJECTED, DOCUMENT_REJECTED",
         ]
     )
-    fun fromDtoToEntity(dto: CommunicationConfirmationReasonDto, expectedEntity: OfflineCommunicationReasonEntity) {
+    fun `from entity to dto`(entityEnum: OfflineCommunicationReasonEntity, dtoEnum: CommunicationConfirmationReasonDto) {
         // Given
 
         // When
-        val actual = mapper.fromDtoToEntity(dto)
+        val actualFromEntityToDto = mapper.fromEntityToDto(entityEnum)
 
         // Then
-        assertThat(actual).isEqualTo(expectedEntity)
+        assertThat(actualFromEntityToDto).isEqualTo(dtoEnum)
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            "APPLICATION_REJECTED, APPLICATION_REJECTED",
+            "PHOTO_REJECTED, PHOTO_REJECTED",
+            "DOCUMENT_REJECTED, DOCUMENT_REJECTED",
+        ]
+    )
+    fun `from dto to entity`(dtoEnum: CommunicationConfirmationReasonDto, entityEnum: OfflineCommunicationReasonEntity) {
+        // Given
+
+        // When
+        val actualFromDtoToEntity = mapper.fromDtoToEntity(dtoEnum)
+
+        // Then
+        assertThat(actualFromDtoToEntity).isEqualTo(entityEnum)
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/DateTimeMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/DateTimeMapperTest.kt
@@ -1,0 +1,35 @@
+package uk.gov.dluhc.notificationsapi.mapper
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset.UTC
+
+class DateTimeMapperTest {
+    private val mapper = DateTimeMapper()
+
+    @Test
+    fun `should map a LocalDateTime value to OffsetDateTime at UTC`() {
+        // Given
+        val localDateTime = LocalDateTime.of(2022, 4, 1, 9, 15, 30)
+        val expectedOffsetDateTime = OffsetDateTime.of(localDateTime, UTC)
+
+        // When
+        val actual = mapper.toUtcOffset(localDateTime)
+
+        // Then
+        assertThat(actual).isEqualTo(expectedOffsetDateTime)
+    }
+
+    @Test
+    fun `should return null when the parameter is null`() {
+        // Given
+
+        // When
+        val actual = mapper.toUtcOffset(null)
+
+        // Then
+        assertThat(actual).isNull()
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GetCommunicationConfirmationHistoryByApplicationIdIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GetCommunicationConfirmationHistoryByApplicationIdIntegrationTest.kt
@@ -1,12 +1,27 @@
 package uk.gov.dluhc.notificationsapi.rest
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
 import uk.gov.dluhc.notificationsapi.config.IntegrationTest
+import uk.gov.dluhc.notificationsapi.database.entity.CommunicationConfirmationChannel
+import uk.gov.dluhc.notificationsapi.database.entity.CommunicationConfirmationReason
+import uk.gov.dluhc.notificationsapi.models.CommunicationConfirmationHistoryResponse
+import uk.gov.dluhc.notificationsapi.models.OfflineCommunicationChannel
+import uk.gov.dluhc.notificationsapi.models.OfflineCommunicationReason
 import uk.gov.dluhc.notificationsapi.testsupport.bearerToken
+import uk.gov.dluhc.notificationsapi.testsupport.model.buildElectoralRegistrationOfficeResponse
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.UNAUTHORIZED_BEARER_TOKEN
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.aRandomCommunicationConfirmationId
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.aRandomSourceReference
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.aRequestor
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.database.entity.aCommunicationConfirmationBuilder
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.getBearerTokenWithAllRolesExcept
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.getVCAnonymousAdminBearerToken
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.models.aCommunicationConfirmationHistoryEntryBuilder
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 
 internal class GetCommunicationConfirmationHistoryByApplicationIdIntegrationTest : IntegrationTest() {
 
@@ -63,5 +78,72 @@ internal class GetCommunicationConfirmationHistoryByApplicationIdIntegrationTest
             .exchange()
             .expectStatus()
             .isForbidden
+    }
+
+    @Test
+    fun `should successfully fetch the offline communication confirmation history for an anonymous application`() {
+        // Given
+        wireMockService.stubCognitoJwtIssuerResponse()
+        val eroResponse = buildElectoralRegistrationOfficeResponse(id = ERO_ID)
+        wireMockService.stubEroManagementGetEroByEroId(eroResponse, ERO_ID)
+
+        val applicationId = aRandomSourceReference()
+        val requestor = aRequestor()
+
+        val sentConfirmation1 = aCommunicationConfirmationBuilder(
+            id = aRandomCommunicationConfirmationId(),
+            gssCode = eroResponse.localAuthorities[0].gssCode,
+            sourceReference = applicationId,
+            reason = CommunicationConfirmationReason.DOCUMENT_REJECTED,
+            channel = CommunicationConfirmationChannel.LETTER,
+            requestor = requestor,
+            sentAt = LocalDateTime.of(2022, 10, 4, 13, 22, 18),
+        )
+        communicationConfirmationRepository.saveCommunicationConfirmation(sentConfirmation1)
+
+        val sentConfirmation2 = aCommunicationConfirmationBuilder(
+            id = aRandomCommunicationConfirmationId(),
+            gssCode = eroResponse.localAuthorities[0].gssCode,
+            sourceReference = applicationId,
+            reason = CommunicationConfirmationReason.PHOTO_REJECTED,
+            channel = CommunicationConfirmationChannel.EMAIL,
+            requestor = requestor,
+            sentAt = LocalDateTime.of(2022, 10, 6, 9, 58, 24),
+        )
+        communicationConfirmationRepository.saveCommunicationConfirmation(sentConfirmation2)
+
+        val expected = CommunicationConfirmationHistoryResponse(
+            communicationConfirmations = listOf(
+                aCommunicationConfirmationHistoryEntryBuilder(
+                    id = sentConfirmation2.id!!,
+                    gssCode = eroResponse.localAuthorities[0].gssCode,
+                    reason = OfflineCommunicationReason.PHOTO_MINUS_REJECTED,
+                    channel = OfflineCommunicationChannel.EMAIL,
+                    requestor = requestor,
+                    timestamp = OffsetDateTime.of(sentConfirmation2.sentAt, ZoneOffset.UTC),
+                ),
+                aCommunicationConfirmationHistoryEntryBuilder(
+                    id = sentConfirmation1.id!!,
+                    gssCode = eroResponse.localAuthorities[0].gssCode,
+                    reason = OfflineCommunicationReason.DOCUMENT_MINUS_REJECTED,
+                    channel = OfflineCommunicationChannel.LETTER,
+                    requestor = requestor,
+                    timestamp = OffsetDateTime.of(sentConfirmation1.sentAt, ZoneOffset.UTC),
+                )
+            )
+        )
+
+        // When
+        val response = webTestClient.get()
+            .uri(URI_TEMPLATE, ERO_ID, applicationId)
+            // the group ero-vc-anonymous-admin-$ERO_ID is required to be successful
+            .bearerToken(getVCAnonymousAdminBearerToken(ERO_ID, requestor))
+            .contentType(MediaType.APPLICATION_JSON)
+            .exchange()
+
+        // Then
+        response.expectStatus().isOk
+        val actual = response.returnResult(CommunicationConfirmationHistoryResponse::class.java).responseBody.blockFirst()
+        assertThat(actual).isEqualTo(expected)
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GetCommunicationHistoryByApplicationIdIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GetCommunicationHistoryByApplicationIdIntegrationTest.kt
@@ -2,7 +2,6 @@ package uk.gov.dluhc.notificationsapi.rest
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.times
 import org.springframework.http.MediaType
 import uk.gov.dluhc.notificationsapi.config.IntegrationTest
 import uk.gov.dluhc.notificationsapi.database.entity.Channel

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/CommonDataBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/CommonDataBuilder.kt
@@ -42,6 +42,10 @@ fun aNotificationPersonalisationMap(): Map<String, String> = mapOf(
     "date" to "15/Oct/2022"
 )
 
+fun aCommunicationConfirmationId(): UUID = UUID.fromString("fa7d3cc2-2983-4d7e-b675-57d882003ecf")
+
+fun aRandomCommunicationConfirmationId(): UUID = UUID.randomUUID()
+
 fun aLocalDateTime(): LocalDateTime = LocalDateTime.of(2022, 10, 6, 9, 58, 24)
 
 fun anOffsetDateTime(): OffsetDateTime = OffsetDateTime.of(2022, 10, 6, 9, 58, 24, 0, ZoneOffset.UTC)

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/dto/CreateOfflineCommunicationConfirmationDtoBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/dto/CreateOfflineCommunicationConfirmationDtoBuilder.kt
@@ -4,14 +4,17 @@ import uk.gov.dluhc.notificationsapi.dto.CommunicationConfirmationChannelDto
 import uk.gov.dluhc.notificationsapi.dto.CommunicationConfirmationDto
 import uk.gov.dluhc.notificationsapi.dto.CommunicationConfirmationReasonDto
 import uk.gov.dluhc.notificationsapi.dto.SourceType
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.aCommunicationConfirmationId
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aGssCode
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aLocalDateTime
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aSourceReference
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aValidKnownEroId
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.anEmailAddress
 import java.time.LocalDateTime
+import java.util.UUID
 
 fun aCommunicationConfirmationDtoBuilder(
+    id: UUID? = aCommunicationConfirmationId(),
     eroId: String = aValidKnownEroId(),
     sourceReference: String = aSourceReference(),
     sourceType: SourceType = SourceType.ANONYMOUS_ELECTOR_DOCUMENT,
@@ -21,6 +24,7 @@ fun aCommunicationConfirmationDtoBuilder(
     requestor: String = anEmailAddress(),
     sentAt: LocalDateTime = aLocalDateTime(),
 ) = CommunicationConfirmationDto(
+    id = id,
     eroId = eroId,
     gssCode = gssCode,
     sourceReference = sourceReference,

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/models/CommunicationConfirmationHistoryEntryBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/models/CommunicationConfirmationHistoryEntryBuilder.kt
@@ -1,0 +1,27 @@
+package uk.gov.dluhc.notificationsapi.testsupport.testdata.models
+
+import uk.gov.dluhc.notificationsapi.models.CommunicationConfirmationHistoryEntry
+import uk.gov.dluhc.notificationsapi.models.OfflineCommunicationChannel
+import uk.gov.dluhc.notificationsapi.models.OfflineCommunicationReason
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.aCommunicationConfirmationId
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.aRequestor
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.anOffsetDateTime
+import java.time.OffsetDateTime
+import java.util.UUID
+
+fun aCommunicationConfirmationHistoryEntryBuilder(
+    id: UUID = aCommunicationConfirmationId(),
+    gssCode: String,
+    reason: OfflineCommunicationReason = OfflineCommunicationReason.APPLICATION_MINUS_REJECTED,
+    channel: OfflineCommunicationChannel = OfflineCommunicationChannel.EMAIL,
+    requestor: String = aRequestor(),
+    timestamp: OffsetDateTime = anOffsetDateTime(),
+): CommunicationConfirmationHistoryEntry =
+    CommunicationConfirmationHistoryEntry(
+        id = id,
+        gssCode = gssCode,
+        reason = reason,
+        channel = channel,
+        requestor = requestor,
+        timestamp = timestamp,
+    )

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/models/CreateOfflineCommunicationConfirmationRequestBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/models/CreateOfflineCommunicationConfirmationRequestBuilder.kt
@@ -1,0 +1,16 @@
+package uk.gov.dluhc.notificationsapi.testsupport.testdata.models
+
+import uk.gov.dluhc.notificationsapi.models.CreateOfflineCommunicationConfirmationRequest
+import uk.gov.dluhc.notificationsapi.models.OfflineCommunicationChannel
+import uk.gov.dluhc.notificationsapi.models.OfflineCommunicationReason
+
+fun aCreateOfflineCommunicationConfirmationRequestBuilder(
+    gssCode: String,
+    reason: OfflineCommunicationReason = OfflineCommunicationReason.APPLICATION_MINUS_REJECTED,
+    channel: OfflineCommunicationChannel = OfflineCommunicationChannel.EMAIL,
+): CreateOfflineCommunicationConfirmationRequest =
+    CreateOfflineCommunicationConfirmationRequest(
+        gssCode = gssCode,
+        reason = reason,
+        channel = channel,
+    )

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
This PR adds the implementation to return the Communication Confirmation entities that have been stored in a DynamoDb Table.