### PR TITLE
EIP1-4956 - Consistent use of ErrorResponse; plus test time zone fix

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/rest/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/rest/GlobalExceptionHandler.kt
@@ -18,19 +18,50 @@ import uk.gov.dluhc.notificationsapi.client.GovNotifyApiNotFoundException
 import uk.gov.dluhc.notificationsapi.config.ApiRequestErrorAttributes
 import uk.gov.dluhc.notificationsapi.exception.GssCodeMismatchException
 import uk.gov.dluhc.notificationsapi.exception.NotificationTemplateNotFoundException
+import uk.gov.dluhc.notificationsapi.models.ErrorResponse
 import javax.servlet.RequestDispatcher.ERROR_MESSAGE
 import javax.servlet.RequestDispatcher.ERROR_STATUS_CODE
 
+/**
+ * Global Exception Handler. Handles specific exceptions thrown by the application by returning a suitable [ErrorResponse]
+ * response entity.
+ *
+ * Our standard pattern here is to return an [ErrorResponse]. Please think carefully about writing a response handler
+ * method that does not follow this pattern. Please try not to use [handleExceptionInternal] as this returns a response
+ * body of a simple string rather than a structured response body.
+ *
+ * Our preferred approach is to use the method [populateErrorResponseAndHandleExceptionInternal] which builds and returns
+ * the [ErrorResponse] complete with correctly populated status code field. This method also populates the message field
+ * of [ErrorResponse] from the exception. In the case that the exception message is not suitable for exposing through
+ * the REST API, this can be overridden by manually setting the message on the request attribute. eg:
+ *
+ * ```
+ *     request.setAttribute(ERROR_MESSAGE, "A simpler error message that does not expose internal detail", SCOPE_REQUEST)
+ * ```
+ *
+ */
 @ControllerAdvice
 class GlobalExceptionHandler(
     private var errorAttributes: ApiRequestErrorAttributes
 ) : ResponseEntityExceptionHandler() {
 
-    @ExceptionHandler(value = [GovNotifyApiNotFoundException::class])
+    /**
+     * Exception handler to return a 400 Bad Request ErrorResponse, specifically for a GovNotifyApiNotFoundException.
+     *
+     * This is because the message property of GovNotifyApiNotFoundException contains too much detail of the nature of
+     * the error, and we would be exposing details of the internals of the system. Therefore we manually set the error
+     * message request attribute to something more suitable before using it to create the ErrorResponse which is
+     * rendered through the REST API. The actual exception detail is logged at the service/client layer.
+     */
+    @ExceptionHandler(
+        value = [
+            GovNotifyApiNotFoundException::class,
+        ]
+    )
     protected fun handleGovNotifyApiNotFoundException(
         e: GovNotifyApiNotFoundException,
-        request: WebRequest
-    ): ResponseEntity<Any>? {
+        request: WebRequest,
+    ): ResponseEntity<Any> {
         request.setAttribute(
             ERROR_MESSAGE,
             "Notification template not found for the given template type",
@@ -39,49 +70,50 @@ class GlobalExceptionHandler(
         return populateErrorResponseAndHandleExceptionInternal(e, NOT_FOUND, request)
     }
 
+    /**
+     * Exception handler to return a 400 Bad Request ErrorResponse
+     */
     @ExceptionHandler(
         value = [
             GovNotifyApiBadRequestException::class,
             GssCodeMismatchException::class,
-        ]
-    )
-    protected fun handleBadRequestException(
-        e: Exception,
-        request: WebRequest
-    ): ResponseEntity<Any>? {
-        return populateErrorResponseAndHandleExceptionInternal(e, BAD_REQUEST, request)
-    }
-
-    @ExceptionHandler(
-        value = [
             NotificationTemplateNotFoundException::class,
         ]
     )
-    protected fun handleNotificationTemplateNotFoundException(
+    protected fun handleExceptionReturnBadRequestErrorResponse(
         e: Exception,
         request: WebRequest
-    ): ResponseEntity<Any>? {
+    ): ResponseEntity<Any> {
         return populateErrorResponseAndHandleExceptionInternal(e, BAD_REQUEST, request)
     }
 
+    /**
+     * Overrides the HttpMessageNotReadableException exception handler to return a 400 Bad Request ErrorResponse
+     */
     override fun handleHttpMessageNotReadable(
         e: HttpMessageNotReadableException,
         headers: HttpHeaders,
         status: HttpStatus,
-        request: WebRequest
+        request: WebRequest,
     ): ResponseEntity<Any> {
-        return populateErrorResponseAndHandleExceptionInternal(e, status, request)
+        return populateErrorResponseAndHandleExceptionInternal(e, BAD_REQUEST, request)
     }
 
+    /**
+     * Overrides the MethodArgumentNotValidException exception handler to return a 400 Bad Request ErrorResponse
+     */
     override fun handleMethodArgumentNotValid(
         e: MethodArgumentNotValidException,
         headers: HttpHeaders,
         status: HttpStatus,
-        request: WebRequest
+        request: WebRequest,
     ): ResponseEntity<Any> {
-        return populateErrorResponseAndHandleExceptionInternal(e, status, request)
+        return populateErrorResponseAndHandleExceptionInternal(e, BAD_REQUEST, request)
     }
 
+    /**
+     * Overrides the TypeMismatchException exception handler to return a 400 Bad Request ErrorResponse
+     */
     override fun handleTypeMismatch(
         ex: TypeMismatchException,
         headers: HttpHeaders,
@@ -89,13 +121,13 @@ class GlobalExceptionHandler(
         request: WebRequest
     ): ResponseEntity<Any> {
         request.setAttribute(ERROR_MESSAGE, ex.cause?.message ?: "", SCOPE_REQUEST)
-        return populateErrorResponseAndHandleExceptionInternal(ex, status, request)
+        return populateErrorResponseAndHandleExceptionInternal(ex, BAD_REQUEST, request)
     }
 
     private fun populateErrorResponseAndHandleExceptionInternal(
         exception: Exception,
         status: HttpStatus,
-        request: WebRequest
+        request: WebRequest,
     ): ResponseEntity<Any> {
         request.setAttribute(ERROR_STATUS_CODE, status.value(), SCOPE_REQUEST)
         val body = errorAttributes.getErrorResponse(request)

--- a/src/main/resources/openapi/NotificationsAPIs.yaml
+++ b/src/main/resources/openapi/NotificationsAPIs.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Notifications APIs
-  version: '1.11.1'
+  version: '1.11.2'
   description: Notifications APIs
   contact:
     name: Krister Bone
@@ -165,21 +165,7 @@ paths:
         '204':
           description: The offline communication confirmation was successfully processed
         '400':
-          description: Error response describing fields in the request payload that are in error
-          headers:
-            Access-Control-Allow-Origin:
-              schema:
-                type: string
-            Access-Control-Allow-Methods:
-              schema:
-                type: string
-            Access-Control-Allow-Headers:
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
+          $ref: '#/components/responses/400ErrorResponse'
       security:
         - eroUserCognitoUserPoolAuthorizer: [ ]
       x-amazon-apigateway-integration:
@@ -277,21 +263,7 @@ paths:
         '201':
           $ref: '#/components/responses/GenerateTemplatePreview'
         '400':
-          description: Error response describing fields in the request payload that are in error
-          headers:
-            Access-Control-Allow-Origin:
-              schema:
-                type: string
-            Access-Control-Allow-Methods:
-              schema:
-                type: string
-            Access-Control-Allow-Headers:
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
+          $ref: '#/components/responses/400ErrorResponse'
       security:
         - eroUserCognitoUserPoolAuthorizer: [ ]
       x-amazon-apigateway-integration:
@@ -360,21 +332,7 @@ paths:
         '201':
           $ref: '#/components/responses/GenerateTemplatePreview'
         '400':
-          description: Error response describing fields in the request payload that are in error
-          headers:
-            Access-Control-Allow-Origin:
-              schema:
-                type: string
-            Access-Control-Allow-Methods:
-              schema:
-                type: string
-            Access-Control-Allow-Headers:
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
+          $ref: '#/components/responses/400ErrorResponse'
       security:
         - eroUserCognitoUserPoolAuthorizer: [ ]
       x-amazon-apigateway-integration:
@@ -443,21 +401,7 @@ paths:
         '201':
           $ref: '#/components/responses/GenerateTemplatePreview'
         '400':
-          description: Error response describing fields in the request payload that are in error
-          headers:
-            Access-Control-Allow-Origin:
-              schema:
-                type: string
-            Access-Control-Allow-Methods:
-              schema:
-                type: string
-            Access-Control-Allow-Headers:
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
+          $ref: '#/components/responses/400ErrorResponse'
       security:
         - eroUserCognitoUserPoolAuthorizer: [ ]
       x-amazon-apigateway-integration:
@@ -526,21 +470,7 @@ paths:
         '201':
           $ref: '#/components/responses/GenerateTemplatePreview'
         '400':
-          description: Error response describing fields in the request payload that are in error
-          headers:
-            Access-Control-Allow-Origin:
-              schema:
-                type: string
-            Access-Control-Allow-Methods:
-              schema:
-                type: string
-            Access-Control-Allow-Headers:
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
+          $ref: '#/components/responses/400ErrorResponse'
       security:
         - eroUserCognitoUserPoolAuthorizer: [ ]
       x-amazon-apigateway-integration:
@@ -609,21 +539,7 @@ paths:
         '201':
           $ref: '#/components/responses/GenerateTemplatePreview'
         '400':
-          description: Error response describing fields in the request payload that are in error
-          headers:
-            Access-Control-Allow-Origin:
-              schema:
-                type: string
-            Access-Control-Allow-Methods:
-              schema:
-                type: string
-            Access-Control-Allow-Headers:
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
+          $ref: '#/components/responses/400ErrorResponse'
       security:
         - eroUserCognitoUserPoolAuthorizer: [ ]
       x-amazon-apigateway-integration:
@@ -645,7 +561,9 @@ components:
   schemas:
     ErrorResponse:
       title: ErrorResponse
-      description: Response describing errors in a web request
+      description: |
+        A generic response body object describing errors in a web request, and can be used to communicate several
+        different types of error condition such as (but not limited to) `400 BAD REQUEST`, `409 CONFLICT` etc.
       properties:
         timestamp:
           type: string
@@ -659,13 +577,13 @@ components:
           example: 'Bad Request'
         message:
           type: string
-          example: 'Validation failed for object=''GenerateTemplatePreviewRequest''. Error count: 1'
+          example: 'Validation failed for object=applicationRequest. Error count: 14'
         validationErrors:
+          description: Validation errors are only present if the error being described is a `400 BAD REQUEST`.
           type: array
           items:
             type: string
-          example:
-            - 'Error on field ''channel'': rejected value [email]'
+          example: 'Error on field applicant.nino: rejected value [aaaaaaaaaaa], must match ^.{1,10}$'
       required:
         - timestamp
         - status
@@ -1128,6 +1046,74 @@ components:
   # Response Body Definitions
   # --------------------------------------------------------------------------------
   responses:
+    400ErrorResponse:
+      description: Error response for a HTTP 400 describing fields in the request payload that are in error
+      headers:
+        Access-Control-Allow-Origin:
+          schema:
+            type: string
+        Access-Control-Allow-Methods:
+          schema:
+            type: string
+        Access-Control-Allow-Headers:
+          schema:
+            type: string
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            timestamp: '2022-09-28T18:01:42.105Z'
+            status: 400
+            error: 'Bad Request'
+            message: 'Validation failed for object=applicationRequest. Error count: 14'
+            validationErrors: 'Error on field applicant.nino: rejected value [aaaaaaaaaaa], must match ^.{1,10}$'
+    404ErrorResponse:
+      description: |
+        Error response for a HTTP 404 describing the problem with the request.
+        Typical examples are resources such as the application not found.
+      headers:
+        Access-Control-Allow-Origin:
+          schema:
+            type: string
+        Access-Control-Allow-Methods:
+          schema:
+            type: string
+        Access-Control-Allow-Headers:
+          schema:
+            type: string
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            timestamp: '2022-09-28T18:01:42.105Z'
+            status: 404
+            error: 'Not Found'
+            message: 'Certificate photo for voter card application with eroId=[some-ero] and applicationType=[VOTER_CARD] and applicationId=[507f1f77bcf86cd799439011] not found'
+    409ErrorResponse:
+      description: |
+        Error response for a HTTP 409 describing the problem with the request.
+        Typical examples are that an application's status(es) are not in the required state to perform the requested operation.
+      headers:
+        Access-Control-Allow-Origin:
+          schema:
+            type: string
+        Access-Control-Allow-Methods:
+          schema:
+            type: string
+        Access-Control-Allow-Headers:
+          schema:
+            type: string
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            timestamp: '2022-09-28T18:01:42.105Z'
+            status: 409
+            error: 'Conflict'
+            message: 'An application with eroId = some-ero and applicationType = VOTER_CARD and applicationId = 507f1f77bcf86cd799439011 has an unexpected photoCheckStatus = ACCEPTED'
     GenerateTemplatePreview:
       description: Response containing the result of template previews in text and html format
       headers:

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/config/ApiRequestErrorAttributesTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/config/ApiRequestErrorAttributesTest.kt
@@ -8,7 +8,7 @@ import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.validation.BindException
 import org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST
 import org.springframework.web.context.request.ServletWebRequest
-import uk.gov.dluhc.notificationsapi.testsupport.model.ErrorResponseAssert.Companion.assertThat
+import uk.gov.dluhc.notificationsapi.testsupport.assertj.assertions.models.ErrorResponseAssert.Companion.assertThat
 import java.time.OffsetDateTime
 import java.time.temporal.ChronoUnit
 import javax.servlet.RequestDispatcher

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/config/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/config/IntegrationTest.kt
@@ -25,6 +25,7 @@ import uk.gov.dluhc.notificationsapi.testsupport.WiremockService
 import uk.gov.dluhc.notificationsapi.testsupport.getDifferentRandomEroId
 import uk.gov.dluhc.notificationsapi.testsupport.getRandomEroId
 import uk.gov.service.notify.NotificationClient
+import java.time.Clock
 
 /**
  * Base class used to bring up the entire Spring ApplicationContext
@@ -105,6 +106,9 @@ internal abstract class IntegrationTest {
 
     @Autowired
     protected lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    protected lateinit var clock: Clock
 
     companion object {
         val ERO_ID = getRandomEroId()

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/CreateOfflineCommunicationConfirmationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/CreateOfflineCommunicationConfirmationIntegrationTest.kt
@@ -12,7 +12,7 @@ import uk.gov.dluhc.notificationsapi.database.entity.SourceType
 import uk.gov.dluhc.notificationsapi.models.CreateOfflineCommunicationConfirmationRequest
 import uk.gov.dluhc.notificationsapi.models.OfflineCommunicationChannel
 import uk.gov.dluhc.notificationsapi.models.OfflineCommunicationReason
-import uk.gov.dluhc.notificationsapi.testsupport.assertj.assertions.entity.CommunicationConfirmationAssert
+import uk.gov.dluhc.notificationsapi.testsupport.assertj.assertions.entity.CommunicationConfirmationAssert.Companion.assertThat
 import uk.gov.dluhc.notificationsapi.testsupport.bearerToken
 import uk.gov.dluhc.notificationsapi.testsupport.model.buildElectoralRegistrationOfficeResponse
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.UNAUTHORIZED_BEARER_TOKEN
@@ -130,14 +130,14 @@ internal class CreateOfflineCommunicationConfirmationIntegrationTest : Integrati
             gssCodes = listOf(gssCode)
         )
         assertThat(actualEntity).hasSize(1)
-        CommunicationConfirmationAssert.assertThat(actualEntity.first())
+        assertThat(actualEntity.first())
             .hasGssCode(gssCode)
             .hasReason(CommunicationConfirmationReason.APPLICATION_REJECTED)
             .hasChannel(CommunicationConfirmationChannel.LETTER)
             .hasRequestor(requestor)
             .hasSourceReference(sourceReference)
             .hasSourceType(SourceType.ANONYMOUS_ELECTOR_DOCUMENT)
-            .sentAtIsCloseTo(now(), within(3, SECONDS))
+            .sentAtIsCloseTo(now(clock), within(3, SECONDS))
     }
 
     private fun buildBody(

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GenerateApplicationApprovedTemplatePreviewIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GenerateApplicationApprovedTemplatePreviewIntegrationTest.kt
@@ -11,8 +11,8 @@ import uk.gov.dluhc.notificationsapi.models.ErrorResponse
 import uk.gov.dluhc.notificationsapi.models.GenerateApplicationApprovedTemplatePreviewRequest
 import uk.gov.dluhc.notificationsapi.models.GenerateTemplatePreviewResponse
 import uk.gov.dluhc.notificationsapi.models.SourceType
+import uk.gov.dluhc.notificationsapi.testsupport.assertj.assertions.models.ErrorResponseAssert.Companion.assertThat
 import uk.gov.dluhc.notificationsapi.testsupport.bearerToken
-import uk.gov.dluhc.notificationsapi.testsupport.model.ErrorResponseAssert.Companion.assertThat
 import uk.gov.dluhc.notificationsapi.testsupport.model.NotifyGenerateTemplatePreviewSuccessResponse
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.UNAUTHORIZED_BEARER_TOKEN
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.api.buildAddressRequestWithOptionalParamsNull

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GenerateApplicationRejectedTemplatePreviewIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GenerateApplicationRejectedTemplatePreviewIntegrationTest.kt
@@ -17,8 +17,8 @@ import uk.gov.dluhc.notificationsapi.models.GenerateTemplatePreviewResponse
 import uk.gov.dluhc.notificationsapi.models.Language
 import uk.gov.dluhc.notificationsapi.models.Language.CY
 import uk.gov.dluhc.notificationsapi.models.SourceType
+import uk.gov.dluhc.notificationsapi.testsupport.assertj.assertions.models.ErrorResponseAssert.Companion.assertThat
 import uk.gov.dluhc.notificationsapi.testsupport.bearerToken
-import uk.gov.dluhc.notificationsapi.testsupport.model.ErrorResponseAssert
 import uk.gov.dluhc.notificationsapi.testsupport.model.NotifyGenerateTemplatePreviewSuccessResponse
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.UNAUTHORIZED_BEARER_TOKEN
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.getBearerToken
@@ -75,7 +75,7 @@ internal class GenerateApplicationRejectedTemplatePreviewIntegrationTest : Integ
 
         // Then
         val actual = response.responseBody.blockFirst()
-        ErrorResponseAssert.assertThat(actual)
+        assertThat(actual)
             .hasTimestampNotBefore(earliestExpectedTimeStamp)
             .hasStatus(404)
             .hasError("Not Found")
@@ -100,7 +100,7 @@ internal class GenerateApplicationRejectedTemplatePreviewIntegrationTest : Integ
 
         // Then
         val actual = response.responseBody.blockFirst()
-        ErrorResponseAssert.assertThat(actual)
+        assertThat(actual)
             .hasTimestampNotBefore(earliestExpectedTimeStamp)
             .hasStatus(400)
             .hasError("Bad Request")
@@ -127,7 +127,7 @@ internal class GenerateApplicationRejectedTemplatePreviewIntegrationTest : Integ
 
         // Then
         val actual = response.responseBody.blockFirst()
-        ErrorResponseAssert.assertThat(actual)
+        assertThat(actual)
             .hasTimestampNotBefore(earliestExpectedTimeStamp)
             .hasStatus(400)
             .hasError("Bad Request")
@@ -186,7 +186,7 @@ internal class GenerateApplicationRejectedTemplatePreviewIntegrationTest : Integ
 
         // Then
         val actual = response.responseBody.blockFirst()
-        ErrorResponseAssert.assertThat(actual)
+        assertThat(actual)
             .hasTimestampNotBefore(earliestExpectedTimeStamp)
             .hasStatus(400)
             .hasError("Bad Request")

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GenerateIdDocumentRequiredTemplatePreviewIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GenerateIdDocumentRequiredTemplatePreviewIntegrationTest.kt
@@ -18,8 +18,8 @@ import uk.gov.dluhc.notificationsapi.models.Language
 import uk.gov.dluhc.notificationsapi.models.Language.CY
 import uk.gov.dluhc.notificationsapi.models.NotificationChannel.EMAIL
 import uk.gov.dluhc.notificationsapi.models.NotificationChannel.LETTER
+import uk.gov.dluhc.notificationsapi.testsupport.assertj.assertions.models.ErrorResponseAssert
 import uk.gov.dluhc.notificationsapi.testsupport.bearerToken
-import uk.gov.dluhc.notificationsapi.testsupport.model.ErrorResponseAssert
 import uk.gov.dluhc.notificationsapi.testsupport.model.NotifyGenerateTemplatePreviewSuccessResponse
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.UNAUTHORIZED_BEARER_TOKEN
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.getBearerToken

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GenerateIdDocumentResubmissionTemplatePreviewIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GenerateIdDocumentResubmissionTemplatePreviewIntegrationTest.kt
@@ -10,8 +10,8 @@ import uk.gov.dluhc.notificationsapi.config.IntegrationTest
 import uk.gov.dluhc.notificationsapi.models.ErrorResponse
 import uk.gov.dluhc.notificationsapi.models.GenerateIdDocumentResubmissionTemplatePreviewRequest
 import uk.gov.dluhc.notificationsapi.models.GenerateTemplatePreviewResponse
+import uk.gov.dluhc.notificationsapi.testsupport.assertj.assertions.models.ErrorResponseAssert.Companion.assertThat
 import uk.gov.dluhc.notificationsapi.testsupport.bearerToken
-import uk.gov.dluhc.notificationsapi.testsupport.model.ErrorResponseAssert.Companion.assertThat
 import uk.gov.dluhc.notificationsapi.testsupport.model.NotifyGenerateTemplatePreviewSuccessResponse
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.UNAUTHORIZED_BEARER_TOKEN
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.api.buildAddressRequestWithOptionalParamsNull

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GeneratePhotoResubmissionTemplatePreviewIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GeneratePhotoResubmissionTemplatePreviewIntegrationTest.kt
@@ -11,8 +11,8 @@ import uk.gov.dluhc.notificationsapi.models.ErrorResponse
 import uk.gov.dluhc.notificationsapi.models.GeneratePhotoResubmissionTemplatePreviewRequest
 import uk.gov.dluhc.notificationsapi.models.GenerateTemplatePreviewResponse
 import uk.gov.dluhc.notificationsapi.models.SourceType
+import uk.gov.dluhc.notificationsapi.testsupport.assertj.assertions.models.ErrorResponseAssert.Companion.assertThat
 import uk.gov.dluhc.notificationsapi.testsupport.bearerToken
-import uk.gov.dluhc.notificationsapi.testsupport.model.ErrorResponseAssert.Companion.assertThat
 import uk.gov.dluhc.notificationsapi.testsupport.model.NotifyGenerateTemplatePreviewSuccessResponse
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.UNAUTHORIZED_BEARER_TOKEN
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.api.buildAddressRequestWithOptionalParamsNull

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/assertj/assertions/models/ErrorResponseAssert.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/assertj/assertions/models/ErrorResponseAssert.kt
@@ -1,6 +1,7 @@
-package uk.gov.dluhc.notificationsapi.testsupport.model
+package uk.gov.dluhc.notificationsapi.testsupport.assertj.assertions.models
 
 import org.assertj.core.api.AbstractAssert
+import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.dluhc.notificationsapi.models.ErrorResponse
 import java.time.OffsetDateTime
 
@@ -9,6 +10,11 @@ class ErrorResponseAssert(actual: ErrorResponse?) :
 
     companion object {
         fun assertThat(actual: ErrorResponse?) = ErrorResponseAssert(actual)
+
+        fun assertThat(actual: WebTestClient.ResponseSpec): ErrorResponseAssert {
+            val returnResult = actual.returnResult(ErrorResponse::class.java).responseBody.blockFirst()
+            return assertThat(returnResult)
+        }
     }
 
     fun hasTimestampNotBefore(expected: OffsetDateTime): ErrorResponseAssert {
@@ -16,6 +22,16 @@ class ErrorResponseAssert(actual: ErrorResponse?) :
         with(actual!!) {
             if (timestamp.isBefore(expected)) {
                 failWithMessage("Expected timestamp to not be before $expected, but was $timestamp")
+            }
+        }
+        return this
+    }
+
+    fun hasTimestampNotAfter(expected: OffsetDateTime): ErrorResponseAssert {
+        isNotNull
+        with(actual!!) {
+            if (timestamp.isAfter(expected)) {
+                failWithMessage("Expected timestamp to not be after $expected, but was $timestamp")
             }
         }
         return this


### PR DESCRIPTION
This PR updates the openAPI spec and various implementations to make the declaration of REST API error statuses and the implementation consistent (consistent both in terms of a consistent API, and also consistent with VCA in respect of implementation)

I have also fixed a failing test that started to fail since the clocks went forwards .... who doesn't love timezones! 🤣 