### PR TITLE
EIP1-5156 - Logging config to add correlation ID

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
     // api
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-aop")
     implementation("org.springdoc:springdoc-openapi-ui:1.6.14")
     implementation("org.springframework.boot:spring-boot-starter-validation")
 

--- a/src/main/kotlin/uk/gov/dluhc/logging/config/CorrelationIdMdcConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/logging/config/CorrelationIdMdcConfiguration.kt
@@ -1,0 +1,19 @@
+package uk.gov.dluhc.logging.config
+
+import org.slf4j.MDC
+import java.util.UUID
+
+/**
+ * MVC Interceptor and AOP beans that set the correlation ID MDC variable for inclusion in all log statements.
+ *
+ * Copy of https://github.com/cabinetoffice/eip-ero-portal/blob/main/logging-lib/src/main/kotlin/uk/gov/dluhc/logging/config/CorrelationIdMdcConfiguration.kt
+ */
+
+const val CORRELATION_ID = "correlationId"
+const val CORRELATION_ID_HEADER = "x-correlation-id"
+
+fun generateCorrelationId(): String =
+    UUID.randomUUID().toString().replace("-", "")
+
+fun getCurrentCorrelationId(): String =
+    MDC.get(CORRELATION_ID) ?: generateCorrelationId()

--- a/src/main/kotlin/uk/gov/dluhc/logging/config/CorrelationIdMdcMessageListenerAspect.kt
+++ b/src/main/kotlin/uk/gov/dluhc/logging/config/CorrelationIdMdcMessageListenerAspect.kt
@@ -1,0 +1,52 @@
+package uk.gov.dluhc.logging.config
+
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.slf4j.MDC
+import org.springframework.messaging.Message
+import org.springframework.messaging.support.GenericMessage
+
+/**
+ * AOP Aspect to read and set the correlation ID on inbound (received) and outbound SQS [Message]s respectively.
+ * This allows for passing and logging a consistent correlation ID between disparate systems or processes.
+ *
+ * Copy of https://github.com/cabinetoffice/eip-ero-portal/blob/main/logging-lib/src/main/kotlin/uk/gov/dluhc/logging/config/CorrelationIdMdcMessageListenerAspect.kt
+ */
+@Aspect
+class CorrelationIdMdcMessageListenerAspect {
+
+    /**
+     * Around Advice for inbound [Message]s (ie. SQS Message's being directed to a listener class) that sets the correlation ID
+     * MDC variable to the value found in the Message header `x-correlation-id` if set, or a new value.
+     * This allows for passing and logging a consistent correlation ID between disparate systems or processes.
+     */
+    @Around("execution(* org.springframework.messaging.handler.invocation.AbstractMethodMessageHandler.handleMessage(..))")
+    fun aroundHandleMessage(proceedingJoinPoint: ProceedingJoinPoint): Any? {
+        val message = proceedingJoinPoint.args[0] as Message<*>?
+        MDC.put(CORRELATION_ID, message?.headers?.get(CORRELATION_ID_HEADER)?.toString() ?: generateCorrelationId())
+        return proceedingJoinPoint.proceed(proceedingJoinPoint.args).also {
+            MDC.remove(CORRELATION_ID)
+        }
+    }
+
+    /**
+     * Around Advice for outbound [Message]s (ie. SQS Message's being sent) that sets the correlation ID
+     * header on a new [Message] to either the existing MDC variable or a new value if not set in MDC.
+     * This allows for passing and logging a consistent correlation ID between disparate systems or processes.
+     *
+     * The reason this Advice is an Around is because [Message] and it's headers are immutable, so we cannot add
+     * the correlation ID header on the passed [Message]. Therefore we need to create new message with the same
+     * payload and a modified collection of headers.
+     */
+    @Around("execution(* io.awspring.cloud.messaging.core.support.AbstractMessageChannelMessagingSendingTemplate.send(..))")
+    fun aroundSendMessage(proceedingJoinPoint: ProceedingJoinPoint): Any? {
+        val queue = proceedingJoinPoint.args[0]
+        val originalMessage = proceedingJoinPoint.args[1] as Message<*>
+        val newMessage = GenericMessage(
+            originalMessage.payload,
+            originalMessage.headers.toMutableMap().plus(CORRELATION_ID_HEADER to getCurrentCorrelationId())
+        )
+        return proceedingJoinPoint.proceed(arrayOf(queue, newMessage))
+    }
+}

--- a/src/main/kotlin/uk/gov/dluhc/logging/rest/CorrelationIdMdcInterceptor.kt
+++ b/src/main/kotlin/uk/gov/dluhc/logging/rest/CorrelationIdMdcInterceptor.kt
@@ -1,0 +1,35 @@
+package uk.gov.dluhc.logging.rest
+
+import org.slf4j.MDC
+import org.springframework.web.servlet.HandlerInterceptor
+import uk.gov.dluhc.logging.config.CORRELATION_ID
+import uk.gov.dluhc.logging.config.CORRELATION_ID_HEADER
+import uk.gov.dluhc.logging.config.generateCorrelationId
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+/**
+ * MVC Interceptor that sets the correlation ID MDC variable of either a new value, or the value found in the
+ * HTTP header `x-correlation-id` if set. This allows for passing and logging a consistent correlation ID between
+ * disparate systems or processes. This interceptor is used in beans annotated with @RestController.
+ *
+ * Copy of https://github.com/cabinetoffice/eip-ero-portal/blob/main/logging-lib/src/main/kotlin/uk/gov/dluhc/logging/rest/CorrelationIdMdcInterceptor.kt
+ */
+class CorrelationIdMdcInterceptor : HandlerInterceptor {
+
+    override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
+        val correlationId = request.getHeader(CORRELATION_ID_HEADER) ?: generateCorrelationId()
+        MDC.put(CORRELATION_ID, correlationId)
+        response.setHeader(CORRELATION_ID_HEADER, correlationId)
+        return true
+    }
+
+    override fun afterCompletion(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any,
+        ex: Exception?
+    ) {
+        MDC.remove(CORRELATION_ID)
+    }
+}

--- a/src/main/kotlin/uk/gov/dluhc/logging/rest/CorrelationIdWebClientMdcExchangeFilter.kt
+++ b/src/main/kotlin/uk/gov/dluhc/logging/rest/CorrelationIdWebClientMdcExchangeFilter.kt
@@ -1,0 +1,71 @@
+package uk.gov.dluhc.logging.rest
+
+import org.slf4j.MDC
+import org.springframework.http.HttpHeaders
+import org.springframework.web.reactive.function.client.ClientRequest
+import org.springframework.web.reactive.function.client.ClientResponse
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction
+import org.springframework.web.reactive.function.client.ExchangeFunction
+import reactor.core.publisher.Mono
+import uk.gov.dluhc.logging.config.CORRELATION_ID_HEADER
+import uk.gov.dluhc.logging.config.getCurrentCorrelationId
+
+/**
+ * WebClient exchange filter that sets the correlation ID header to either a new value, or the
+ * current value found in the MDC context. This allows for passing and logging a consistent correlation ID between
+ * disparate systems or processes using the spring WebClient.
+ * Example of usage:
+ * ```
+ *   @Configuration
+ *   @Bean
+ *     fun someWebclient(correlationIdExchangeFilter: CorrelationIdMdcExchangeFilter): WebClient =
+ *         WebClient.builder()
+ *             // Other WebClient config
+ *             .filter(correlationIdExchangeFilter)
+ *             .build()
+ *```
+ *
+ * Copy of https://github.com/cabinetoffice/eip-ero-portal/blob/main/logging-lib/src/main/kotlin/uk/gov/dluhc/logging/rest/CorrelationIdWebClientMdcExchangeFilter.kt
+ */
+class CorrelationIdWebClientMdcExchangeFilter : ExchangeFilterFunction {
+
+    /*
+        This is modelled as a set in case we need to talk to another system within the gov space that doesn't use 'x-correlation-id'.
+        Another commonly used identifier is 'X-Request-Id'. This allows us to send our 'x-correlation-id' as well as their specified one.
+    */
+    private val correlationHeaderNames: Set<String> = setOf(CORRELATION_ID_HEADER)
+
+    override fun filter(request: ClientRequest, next: ExchangeFunction): Mono<ClientResponse> {
+        val currentCorrelationId = getCurrentCorrelationId()
+        val clientRequestModified = setCorrelationIdInRequest(request, currentCorrelationId)
+
+        return next.filter(::mdcExchangeFilter).exchange(clientRequestModified)
+    }
+
+    private fun setCorrelationIdInRequest(request: ClientRequest, correlationId: String): ClientRequest {
+        return ClientRequest.from(request)
+            .headers { headers: HttpHeaders ->
+                correlationHeaderNames.forEach { correlationHeaderName ->
+                    headers[correlationHeaderName] = correlationId
+                }
+            }
+            .build()
+    }
+
+    /**
+     * MDC uses thread bound values. In the reactive non-blocking world, a single request could be processed by multiple
+     * threads. This means that setting the MDC context at the beginning of the request is not an option. Since WebClient
+     * uses reactor-netty under the hood, it runs on different threads.
+     *
+     * In order to continue using the MDC feature in the reactive Spring application, we need to make sure that whenever a
+     * thread starts processing a request it has to update the state of the MDC context.
+     */
+    private fun mdcExchangeFilter(request: ClientRequest, next: ExchangeFunction): Mono<ClientResponse> {
+        val contextMap = MDC.getCopyOfContextMap()
+        return next.exchange(request).doOnEach { _ ->
+            if (contextMap != null) {
+                MDC.setContextMap(contextMap)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/config/LoggingConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/config/LoggingConfiguration.kt
@@ -1,0 +1,20 @@
+package uk.gov.dluhc.notificationsapi.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import uk.gov.dluhc.logging.config.CorrelationIdMdcMessageListenerAspect
+import uk.gov.dluhc.logging.rest.CorrelationIdMdcInterceptor
+import uk.gov.dluhc.logging.rest.CorrelationIdWebClientMdcExchangeFilter
+
+@Configuration
+class LoggingConfiguration {
+
+    @Bean
+    fun correlationIdMdcInterceptor() = CorrelationIdMdcInterceptor()
+
+    @Bean
+    fun correlationIdMdcMessageListenerAspect() = CorrelationIdMdcMessageListenerAspect()
+
+    @Bean
+    fun correlationIdWebClientMdcExchangeFilter() = CorrelationIdWebClientMdcExchangeFilter()
+}

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/config/WebClientConfiguration.kt
@@ -4,13 +4,18 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.dluhc.logging.rest.CorrelationIdWebClientMdcExchangeFilter
 
 @Configuration
 class WebClientConfiguration {
 
     @Bean
-    fun eroManagementWebClient(@Value("\${api.ero-management.url}") eroManagementApiUrl: String): WebClient =
+    fun eroManagementWebClient(
+        @Value("\${api.ero-management.url}") eroManagementApiUrl: String,
+        correlationIdExchangeFilter: CorrelationIdWebClientMdcExchangeFilter,
+    ): WebClient =
         WebClient.builder()
             .baseUrl(eroManagementApiUrl)
+            .filter(correlationIdExchangeFilter)
             .build()
 }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/config/WebMvcConfig.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/config/WebMvcConfig.kt
@@ -1,0 +1,14 @@
+package uk.gov.dluhc.notificationsapi.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import uk.gov.dluhc.logging.rest.CorrelationIdMdcInterceptor
+
+@Configuration
+class WebMvcConfig(private val correlationIdMdcInterceptor: CorrelationIdMdcInterceptor) : WebMvcConfigurer {
+
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(correlationIdMdcInterceptor)
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,3 +46,7 @@ sqs:
   send-uk-gov-notify-application-approved-queue-name: ${SQS_SEND_UK_GOV_NOTIFY_APPLICATION_APPROVED_QUEUE_NAME}
   send-uk-gov-notify-application-rejected-queue-name: ${SQS_SEND_UK_GOV_NOTIFY_APPLICATION_REJECTED_QUEUE_NAME}
   remove-application-notifications-queue-name: ${SQS_REMOVE_APPLICATION_NOTIFICATIONS_QUEUE_NAME}
+
+logging:
+  pattern:
+    level: "%X{correlationId} %5p"

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,21 +1,10 @@
 <configuration>
     <include resource="org/springframework/boot/logging/logback/base.xml" />
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
-        </encoder>
-    </appender>
     <appender name="testLogAppender" class="uk.gov.dluhc.notificationsapi.testsupport.TestLogAppender"/>
     <root level="info">
-        <appender-ref ref="STDOUT"/>
         <appender-ref ref="testLogAppender"/>
     </root>
 
     <logger name="org.testcontainers" level="INFO"/>
     <logger name="com.github.dockerjava" level="WARN"/>
-
-    <!-- to output SQL and params -->
-<!--    <logger name="org.hibernate.SQL" level="DEBUG"/>-->
-<!--    <logger name="org.hibernate.type.descriptor.sql" level="TRACE"/>-->
-
 </configuration>


### PR DESCRIPTION
This PR adds the same logging config that we use in `print-api` (and will soon'ish be moved out to a shared library) to add the correlation ID to log messages and REST API handlers and SQS messages