### PR TITLE
EIP1-6048 - Added reject reason text to message resource bundle

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/PhotoRejectionReasonMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/PhotoRejectionReasonMapper.kt
@@ -1,0 +1,33 @@
+package uk.gov.dluhc.notificationsapi.mapper
+
+import org.springframework.context.MessageSource
+import org.springframework.stereotype.Component
+import uk.gov.dluhc.notificationsapi.dto.LanguageDto
+import uk.gov.dluhc.notificationsapi.messaging.models.PhotoRejectionReason as PhotoRejectionReasonMessageEnum
+import uk.gov.dluhc.notificationsapi.models.PhotoRejectionReason as PhotoRejectionReasonApiEnum
+
+@Component
+class PhotoRejectionReasonMapper(private val messageSource: MessageSource) {
+
+    fun toPhotoRejectionReasonString(
+        photoRejectionReason: PhotoRejectionReasonApiEnum,
+        languageDto: LanguageDto
+    ): String {
+        return messageSource.getMessage(
+            "templates.photo-rejection.rejection-reasons.${photoRejectionReason.value}",
+            null,
+            languageDto.locale
+        )
+    }
+
+    fun toPhotoRejectionReasonString(
+        photoRejectionReason: PhotoRejectionReasonMessageEnum,
+        languageDto: LanguageDto
+    ): String {
+        return messageSource.getMessage(
+            "templates.photo-rejection.rejection-reasons.${photoRejectionReason.value}",
+            null,
+            languageDto.locale
+        )
+    }
+}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -32,3 +32,13 @@ templates.document-rejection.document-types.utility-bill= Utility bill
 templates.document-rejection.document-types.p45-or-p60-form= P45 or P60 form
 templates.document-rejection.document-types.statement-of-or-entitlement-to-benefits= Statement of or entitlement to benefits
 templates.document-rejection.document-types.completed-attestation-documents= Completed attestation documents
+
+templates.photo-rejection.rejection-reasons.not-facing-forwards-or-looking-at-the-camera= Not facing forwards or looking straight at the camera
+templates.photo-rejection.rejection-reasons.photo-not-in-colour-distorted-or-too-dark= The photo is not in colour, is distorted or is too dark
+templates.photo-rejection.rejection-reasons.other-objects-or-people-in-photo= There are other people or objects in the photo
+templates.photo-rejection.rejection-reasons.not-a-plain-facial-expression= Not a plain facial expression
+templates.photo-rejection.rejection-reasons.eyes-not-open-or-visible-or-hair-in-front-face= Eyes are not open, visible or there is hair in front of the face
+templates.photo-rejection.rejection-reasons.wearing-sunglasses-or-tinted-glasses= Wearing sunglasses, or tinted glasses
+templates.photo-rejection.rejection-reasons.photo-has-head-covering-aside-from-religious-or-medical= The photo has a head covering (aside from religious or medical)
+templates.photo-rejection.rejection-reasons.photo-has-red-eye-glare-or-shadows-over-face= The photo has 'red-eye', glare or shadows over face
+templates.photo-rejection.rejection-reasons.other= Other

--- a/src/main/resources/messages_cy.properties
+++ b/src/main/resources/messages_cy.properties
@@ -7,3 +7,13 @@ templates.application-rejection.rejection-reasons.not-registered-to-vote= Nid yw
 templates.application-rejection.rejection-reasons.duplicate-application= Rydym wedi derbyn un neu fwy o geisiadau dyblyg neu debyg iawn am y manylion a ddarparwyd
 templates.application-rejection.rejection-reasons.no-franchise-to-vote= Mae ein cofnodion yn dangos nad ydych yn gymwys i bleidleisio mewn polau ym Mhrydain Fawr sydd angen prawf adnabod \u00E2 llun
 templates.application-rejection.rejection-reasons.other= Eraill
+
+templates.photo-rejection.rejection-reasons.not-facing-forwards-or-looking-at-the-camera= Nid yw'n gwynebu ymlaen nac edrych yn syth ar y camera
+templates.photo-rejection.rejection-reasons.photo-not-in-colour-distorted-or-too-dark= Nid yw'r llun mewn lliw, mae'n ystumiedig neu'n rhy dywyll
+templates.photo-rejection.rejection-reasons.other-objects-or-people-in-photo= Mae yna bobl neu wrthrychau eraill yn y llun
+templates.photo-rejection.rejection-reasons.not-a-plain-facial-expression= Nid yw'r mynegiant wyneb yn blaen
+templates.photo-rejection.rejection-reasons.eyes-not-open-or-visible-or-hair-in-front-face= Nid yw'r llygaid yn agored, yn weladwy neu mae gwallt o flaen yr wyneb
+templates.photo-rejection.rejection-reasons.wearing-sunglasses-or-tinted-glasses= Gwisgo sbectol haul, neu sbectol arlliw
+templates.photo-rejection.rejection-reasons.photo-has-head-covering-aside-from-religious-or-medical= Mae gan y llun orchudd pen (ar wah\u00E2n i orchudd crefyddol neu feddygol)
+templates.photo-rejection.rejection-reasons.photo-has-red-eye-glare-or-shadows-over-face= Mae gan y llun 'lygad coch', llacharedd neu gysgodion dros yr wyneb
+templates.photo-rejection.rejection-reasons.other= Eraill

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -32,3 +32,13 @@ templates.document-rejection.document-types.utility-bill= Utility bill
 templates.document-rejection.document-types.p45-or-p60-form= P45 or P60 form
 templates.document-rejection.document-types.statement-of-or-entitlement-to-benefits= Statement of or entitlement to benefits
 templates.document-rejection.document-types.completed-attestation-documents= Completed attestation documents
+
+templates.photo-rejection.rejection-reasons.not-facing-forwards-or-looking-at-the-camera= Not facing forwards or looking straight at the camera
+templates.photo-rejection.rejection-reasons.photo-not-in-colour-distorted-or-too-dark= The photo is not in colour, is distorted or is too dark
+templates.photo-rejection.rejection-reasons.other-objects-or-people-in-photo= There are other people or objects in the photo
+templates.photo-rejection.rejection-reasons.not-a-plain-facial-expression= Not a plain facial expression
+templates.photo-rejection.rejection-reasons.eyes-not-open-or-visible-or-hair-in-front-face= Eyes are not open, visible or there is hair in front of the face
+templates.photo-rejection.rejection-reasons.wearing-sunglasses-or-tinted-glasses= Wearing sunglasses, or tinted glasses
+templates.photo-rejection.rejection-reasons.photo-has-head-covering-aside-from-religious-or-medical= The photo has a head covering (aside from religious or medical)
+templates.photo-rejection.rejection-reasons.photo-has-red-eye-glare-or-shadows-over-face= The photo has 'red-eye', glare or shadows over face
+templates.photo-rejection.rejection-reasons.other= Other

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/PhotoRejectionReasonMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/PhotoRejectionReasonMapperTest.kt
@@ -1,0 +1,134 @@
+package uk.gov.dluhc.notificationsapi.mapper
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.springframework.context.support.ResourceBundleMessageSource
+import uk.gov.dluhc.notificationsapi.dto.LanguageDto
+import uk.gov.dluhc.notificationsapi.messaging.models.PhotoRejectionReason as PhotoRejectionReasonMessageEnum
+import uk.gov.dluhc.notificationsapi.models.PhotoRejectionReason as PhotoRejectionReasonApiEnum
+
+class PhotoRejectionReasonMapperTest {
+
+    private val messageSource = ResourceBundleMessageSource().apply {
+        setBasenames("messages")
+        setDefaultEncoding("UTF-8")
+        setFallbackToSystemLocale(true)
+    }
+    private val mapper = PhotoRejectionReasonMapper(messageSource)
+
+    @Nested
+    inner class ToPhotoRejectionReasonStringFromApiEnum {
+        @ParameterizedTest
+        @CsvSource(
+            value = [
+                "NOT_MINUS_FACING_MINUS_FORWARDS_MINUS_OR_MINUS_LOOKING_MINUS_AT_MINUS_THE_MINUS_CAMERA, 'Not facing forwards or looking straight at the camera'",
+                "PHOTO_MINUS_NOT_MINUS_IN_MINUS_COLOUR_MINUS_DISTORTED_MINUS_OR_MINUS_TOO_MINUS_DARK, 'The photo is not in colour, is distorted or is too dark'",
+                "OTHER_MINUS_OBJECTS_MINUS_OR_MINUS_PEOPLE_MINUS_IN_MINUS_PHOTO, 'There are other people or objects in the photo'",
+                "NOT_MINUS_A_MINUS_PLAIN_MINUS_FACIAL_MINUS_EXPRESSION, 'Not a plain facial expression'",
+                "EYES_MINUS_NOT_MINUS_OPEN_MINUS_OR_MINUS_VISIBLE_MINUS_OR_MINUS_HAIR_MINUS_IN_MINUS_FRONT_MINUS_FACE, 'Eyes are not open, visible or there is hair in front of the face'",
+                "WEARING_MINUS_SUNGLASSES_MINUS_OR_MINUS_TINTED_MINUS_GLASSES, 'Wearing sunglasses, or tinted glasses'",
+                "PHOTO_MINUS_HAS_MINUS_HEAD_MINUS_COVERING_MINUS_ASIDE_MINUS_FROM_MINUS_RELIGIOUS_MINUS_OR_MINUS_MEDICAL, 'The photo has a head covering (aside from religious or medical)'",
+                "PHOTO_MINUS_HAS_MINUS_RED_MINUS_EYE_MINUS_GLARE_MINUS_OR_MINUS_SHADOWS_MINUS_OVER_MINUS_FACE, 'The photo has ''red-eye'', glare or shadows over face'",
+                "OTHER, 'Other'"
+            ]
+        )
+        fun `should map enums to human readable messages in English`(
+            rejectionReason: PhotoRejectionReasonApiEnum,
+            expected: String
+        ) {
+            // Given
+
+            // When
+            val actual = mapper.toPhotoRejectionReasonString(rejectionReason, LanguageDto.ENGLISH)
+
+            // Then
+            assertThat(actual).isEqualTo(expected)
+        }
+
+        @ParameterizedTest
+        @CsvSource(
+            value = [
+                "NOT_MINUS_FACING_MINUS_FORWARDS_MINUS_OR_MINUS_LOOKING_MINUS_AT_MINUS_THE_MINUS_CAMERA, 'Nid yw''n gwynebu ymlaen nac edrych yn syth ar y camera'",
+                "PHOTO_MINUS_NOT_MINUS_IN_MINUS_COLOUR_MINUS_DISTORTED_MINUS_OR_MINUS_TOO_MINUS_DARK, 'Nid yw''r llun mewn lliw, mae''n ystumiedig neu''n rhy dywyll'",
+                "OTHER_MINUS_OBJECTS_MINUS_OR_MINUS_PEOPLE_MINUS_IN_MINUS_PHOTO, 'Mae yna bobl neu wrthrychau eraill yn y llun'",
+                "NOT_MINUS_A_MINUS_PLAIN_MINUS_FACIAL_MINUS_EXPRESSION, 'Nid yw''r mynegiant wyneb yn blaen'",
+                "EYES_MINUS_NOT_MINUS_OPEN_MINUS_OR_MINUS_VISIBLE_MINUS_OR_MINUS_HAIR_MINUS_IN_MINUS_FRONT_MINUS_FACE, 'Nid yw''r llygaid yn agored, yn weladwy neu mae gwallt o flaen yr wyneb'",
+                "WEARING_MINUS_SUNGLASSES_MINUS_OR_MINUS_TINTED_MINUS_GLASSES, 'Gwisgo sbectol haul, neu sbectol arlliw'",
+                "PHOTO_MINUS_HAS_MINUS_HEAD_MINUS_COVERING_MINUS_ASIDE_MINUS_FROM_MINUS_RELIGIOUS_MINUS_OR_MINUS_MEDICAL, 'Mae gan y llun orchudd pen (ar wahân i orchudd crefyddol neu feddygol)'",
+                "PHOTO_MINUS_HAS_MINUS_RED_MINUS_EYE_MINUS_GLARE_MINUS_OR_MINUS_SHADOWS_MINUS_OVER_MINUS_FACE, 'Mae gan y llun ''lygad coch'', llacharedd neu gysgodion dros yr wyneb'",
+                "OTHER, 'Eraill'"
+            ]
+        )
+        fun `should map enums to human readable messages in Welsh`(
+            rejectionReason: PhotoRejectionReasonApiEnum,
+            expected: String
+        ) {
+            // Given
+
+            // When
+            val actual = mapper.toPhotoRejectionReasonString(rejectionReason, LanguageDto.WELSH)
+
+            // Then
+            assertThat(actual).isEqualTo(expected)
+        }
+    }
+
+    @Nested
+    inner class ToPhotoRejectionReasonStringFromMessageEnum {
+        @ParameterizedTest
+        @CsvSource(
+            value = [
+                "NOT_MINUS_FACING_MINUS_FORWARDS_MINUS_OR_MINUS_LOOKING_MINUS_AT_MINUS_THE_MINUS_CAMERA, 'Not facing forwards or looking straight at the camera'",
+                "PHOTO_MINUS_NOT_MINUS_IN_MINUS_COLOUR_MINUS_DISTORTED_MINUS_OR_MINUS_TOO_MINUS_DARK, 'The photo is not in colour, is distorted or is too dark'",
+                "OTHER_MINUS_OBJECTS_MINUS_OR_MINUS_PEOPLE_MINUS_IN_MINUS_PHOTO, 'There are other people or objects in the photo'",
+                "NOT_MINUS_A_MINUS_PLAIN_MINUS_FACIAL_MINUS_EXPRESSION, 'Not a plain facial expression'",
+                "EYES_MINUS_NOT_MINUS_OPEN_MINUS_OR_MINUS_VISIBLE_MINUS_OR_MINUS_HAIR_MINUS_IN_MINUS_FRONT_MINUS_FACE, 'Eyes are not open, visible or there is hair in front of the face'",
+                "WEARING_MINUS_SUNGLASSES_MINUS_OR_MINUS_TINTED_MINUS_GLASSES, 'Wearing sunglasses, or tinted glasses'",
+                "PHOTO_MINUS_HAS_MINUS_HEAD_MINUS_COVERING_MINUS_ASIDE_MINUS_FROM_MINUS_RELIGIOUS_MINUS_OR_MINUS_MEDICAL, 'The photo has a head covering (aside from religious or medical)'",
+                "PHOTO_MINUS_HAS_MINUS_RED_MINUS_EYE_MINUS_GLARE_MINUS_OR_MINUS_SHADOWS_MINUS_OVER_MINUS_FACE, 'The photo has ''red-eye'', glare or shadows over face'",
+                "OTHER, 'Other'"
+            ]
+        )
+        fun `should map enums to human readable messages in English`(
+            rejectionReason: PhotoRejectionReasonMessageEnum,
+            expected: String
+        ) {
+            // Given
+
+            // When
+            val actual = mapper.toPhotoRejectionReasonString(rejectionReason, LanguageDto.ENGLISH)
+
+            // Then
+            assertThat(actual).isEqualTo(expected)
+        }
+
+        @ParameterizedTest
+        @CsvSource(
+            value = [
+                "NOT_MINUS_FACING_MINUS_FORWARDS_MINUS_OR_MINUS_LOOKING_MINUS_AT_MINUS_THE_MINUS_CAMERA, 'Nid yw''n gwynebu ymlaen nac edrych yn syth ar y camera'",
+                "PHOTO_MINUS_NOT_MINUS_IN_MINUS_COLOUR_MINUS_DISTORTED_MINUS_OR_MINUS_TOO_MINUS_DARK, 'Nid yw''r llun mewn lliw, mae''n ystumiedig neu''n rhy dywyll'",
+                "OTHER_MINUS_OBJECTS_MINUS_OR_MINUS_PEOPLE_MINUS_IN_MINUS_PHOTO, 'Mae yna bobl neu wrthrychau eraill yn y llun'",
+                "NOT_MINUS_A_MINUS_PLAIN_MINUS_FACIAL_MINUS_EXPRESSION, 'Nid yw''r mynegiant wyneb yn blaen'",
+                "EYES_MINUS_NOT_MINUS_OPEN_MINUS_OR_MINUS_VISIBLE_MINUS_OR_MINUS_HAIR_MINUS_IN_MINUS_FRONT_MINUS_FACE, 'Nid yw''r llygaid yn agored, yn weladwy neu mae gwallt o flaen yr wyneb'",
+                "WEARING_MINUS_SUNGLASSES_MINUS_OR_MINUS_TINTED_MINUS_GLASSES, 'Gwisgo sbectol haul, neu sbectol arlliw'",
+                "PHOTO_MINUS_HAS_MINUS_HEAD_MINUS_COVERING_MINUS_ASIDE_MINUS_FROM_MINUS_RELIGIOUS_MINUS_OR_MINUS_MEDICAL, 'Mae gan y llun orchudd pen (ar wahân i orchudd crefyddol neu feddygol)'",
+                "PHOTO_MINUS_HAS_MINUS_RED_MINUS_EYE_MINUS_GLARE_MINUS_OR_MINUS_SHADOWS_MINUS_OVER_MINUS_FACE, 'Mae gan y llun ''lygad coch'', llacharedd neu gysgodion dros yr wyneb'",
+                "OTHER, 'Eraill'"
+            ]
+        )
+        fun `should map enums to human readable messages in Welsh`(
+            rejectionReason: PhotoRejectionReasonMessageEnum,
+            expected: String
+        ) {
+            // Given
+
+            // When
+            val actual = mapper.toPhotoRejectionReasonString(rejectionReason, LanguageDto.WELSH)
+
+            // Then
+            assertThat(actual).isEqualTo(expected)
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the photo reject reason text and translations to the message resource bundle, and adds a mapper class to be able to resolve the enum to human readable text

The next PR will use this new mapper to include the values in the personalisation map in the gov uk notify template