### PR TITLE
EIP1-4792 / EIP1-6148 - Logic to ensure OTHER is removed from photo rejection list and not used to drive template decision

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/PhotoPersonalisationExtensions.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/PhotoPersonalisationExtensions.kt
@@ -1,0 +1,13 @@
+package uk.gov.dluhc.notificationsapi.mapper
+
+import uk.gov.dluhc.notificationsapi.models.PhotoPersonalisation
+import uk.gov.dluhc.notificationsapi.models.PhotoRejectionReason
+import uk.gov.dluhc.notificationsapi.models.PhotoRejectionReason.OTHER
+
+/**
+ * Extension property on PhotoPersonalisation to return the photo rejection reasons, excluding OTHER
+ * This is because whilst OTHER is a valid rejection reason the ERO can make, it is not to be used in the decision
+ * about which gov.uk template to use, or rendered in the bulleted list of rejection reasons in the rendered template.
+ */
+val PhotoPersonalisation.photoRejectionReasonsExcludingOther: List<PhotoRejectionReason>
+    get() = photoRejectionReasons.filter { it != OTHER }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/PhotoPersonalisationExtensions.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/PhotoPersonalisationExtensions.kt
@@ -1,0 +1,13 @@
+package uk.gov.dluhc.notificationsapi.messaging.mapper
+
+import uk.gov.dluhc.notificationsapi.messaging.models.PhotoPersonalisation
+import uk.gov.dluhc.notificationsapi.messaging.models.PhotoRejectionReason
+import uk.gov.dluhc.notificationsapi.messaging.models.PhotoRejectionReason.OTHER
+
+/**
+ * Extension property on PhotoPersonalisation to return the photo rejection reasons, excluding OTHER
+ * This is because whilst OTHER is a valid rejection reason the ERO can make, it is not to be used in the decision
+ * about which gov.uk template to use, or rendered in the bulleted list of rejection reasons in the rendered template.
+ */
+val PhotoPersonalisation.photoRejectionReasonsExcludingOther: List<PhotoRejectionReason>
+    get() = photoRejectionReasons.filter { it != OTHER }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/SendNotifyMessageMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/SendNotifyMessageMapper.kt
@@ -1,8 +1,11 @@
 package uk.gov.dluhc.notificationsapi.messaging.mapper
 
+import org.apache.commons.lang3.StringUtils.isNotBlank
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping
 import uk.gov.dluhc.notificationsapi.dto.NotificationType
+import uk.gov.dluhc.notificationsapi.dto.NotificationType.PHOTO_RESUBMISSION
+import uk.gov.dluhc.notificationsapi.dto.NotificationType.PHOTO_RESUBMISSION_WITH_REASONS
 import uk.gov.dluhc.notificationsapi.dto.SendNotificationRequestDto
 import uk.gov.dluhc.notificationsapi.mapper.LanguageMapper
 import uk.gov.dluhc.notificationsapi.mapper.NotificationChannelMapper
@@ -60,8 +63,11 @@ abstract class SendNotifyMessageMapper {
     ): SendNotificationRequestDto
 
     protected fun photoResubmissionNotificationType(message: SendNotifyPhotoResubmissionMessage): NotificationType =
-        if (message.personalisation.photoRejectionReasons.isEmpty())
-            NotificationType.PHOTO_RESUBMISSION
-        else
-            NotificationType.PHOTO_RESUBMISSION_WITH_REASONS
+        // PHOTO_RESUBMISSION_WITH_REASONS should be used if there are rejection reasons (excluding OTHER) or there are rejection notes
+        with(message.personalisation) {
+            if (photoRejectionReasonsExcludingOther.isNotEmpty() || isNotBlank(photoRejectionNotes))
+                PHOTO_RESUBMISSION_WITH_REASONS
+            else
+                PHOTO_RESUBMISSION
+        }
 }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/TemplatePersonalisationMessageMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/TemplatePersonalisationMessageMapper.kt
@@ -69,7 +69,7 @@ abstract class TemplatePersonalisationMessageMapper {
         languageDto: LanguageDto,
         personalisation: PhotoPersonalisation
     ): List<String> {
-        return personalisation.photoRejectionReasons.map { reason ->
+        return personalisation.photoRejectionReasonsExcludingOther.map { reason ->
             photoRejectionReasonMapper.toPhotoRejectionReasonString(
                 reason,
                 languageDto

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -41,4 +41,3 @@ templates.photo-rejection.rejection-reasons.eyes-not-open-or-visible-or-hair-in-
 templates.photo-rejection.rejection-reasons.wearing-sunglasses-or-tinted-glasses= Wearing sunglasses, or tinted glasses
 templates.photo-rejection.rejection-reasons.photo-has-head-covering-aside-from-religious-or-medical= The photo has a head covering (aside from religious or medical)
 templates.photo-rejection.rejection-reasons.photo-has-red-eye-glare-or-shadows-over-face= The photo has 'red-eye', glare or shadows over face
-templates.photo-rejection.rejection-reasons.other= Other

--- a/src/main/resources/messages_cy.properties
+++ b/src/main/resources/messages_cy.properties
@@ -16,4 +16,3 @@ templates.photo-rejection.rejection-reasons.eyes-not-open-or-visible-or-hair-in-
 templates.photo-rejection.rejection-reasons.wearing-sunglasses-or-tinted-glasses= Gwisgo sbectol haul, neu sbectol arlliw
 templates.photo-rejection.rejection-reasons.photo-has-head-covering-aside-from-religious-or-medical= Mae gan y llun orchudd pen (ar wah\u00E2n i orchudd crefyddol neu feddygol)
 templates.photo-rejection.rejection-reasons.photo-has-red-eye-glare-or-shadows-over-face= Mae gan y llun 'lygad coch', llacharedd neu gysgodion dros yr wyneb
-templates.photo-rejection.rejection-reasons.other= Eraill

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -41,4 +41,3 @@ templates.photo-rejection.rejection-reasons.eyes-not-open-or-visible-or-hair-in-
 templates.photo-rejection.rejection-reasons.wearing-sunglasses-or-tinted-glasses= Wearing sunglasses, or tinted glasses
 templates.photo-rejection.rejection-reasons.photo-has-head-covering-aside-from-religious-or-medical= The photo has a head covering (aside from religious or medical)
 templates.photo-rejection.rejection-reasons.photo-has-red-eye-glare-or-shadows-over-face= The photo has 'red-eye', glare or shadows over face
-templates.photo-rejection.rejection-reasons.other= Other

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/PhotoRejectionReasonMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/PhotoRejectionReasonMapperTest.kt
@@ -31,7 +31,6 @@ class PhotoRejectionReasonMapperTest {
                 "WEARING_MINUS_SUNGLASSES_MINUS_OR_MINUS_TINTED_MINUS_GLASSES, 'Wearing sunglasses, or tinted glasses'",
                 "PHOTO_MINUS_HAS_MINUS_HEAD_MINUS_COVERING_MINUS_ASIDE_MINUS_FROM_MINUS_RELIGIOUS_MINUS_OR_MINUS_MEDICAL, 'The photo has a head covering (aside from religious or medical)'",
                 "PHOTO_MINUS_HAS_MINUS_RED_MINUS_EYE_MINUS_GLARE_MINUS_OR_MINUS_SHADOWS_MINUS_OVER_MINUS_FACE, 'The photo has ''red-eye'', glare or shadows over face'",
-                "OTHER, 'Other'"
             ]
         )
         fun `should map enums to human readable messages in English`(
@@ -58,7 +57,6 @@ class PhotoRejectionReasonMapperTest {
                 "WEARING_MINUS_SUNGLASSES_MINUS_OR_MINUS_TINTED_MINUS_GLASSES, 'Gwisgo sbectol haul, neu sbectol arlliw'",
                 "PHOTO_MINUS_HAS_MINUS_HEAD_MINUS_COVERING_MINUS_ASIDE_MINUS_FROM_MINUS_RELIGIOUS_MINUS_OR_MINUS_MEDICAL, 'Mae gan y llun orchudd pen (ar wahân i orchudd crefyddol neu feddygol)'",
                 "PHOTO_MINUS_HAS_MINUS_RED_MINUS_EYE_MINUS_GLARE_MINUS_OR_MINUS_SHADOWS_MINUS_OVER_MINUS_FACE, 'Mae gan y llun ''lygad coch'', llacharedd neu gysgodion dros yr wyneb'",
-                "OTHER, 'Eraill'"
             ]
         )
         fun `should map enums to human readable messages in Welsh`(
@@ -88,7 +86,6 @@ class PhotoRejectionReasonMapperTest {
                 "WEARING_MINUS_SUNGLASSES_MINUS_OR_MINUS_TINTED_MINUS_GLASSES, 'Wearing sunglasses, or tinted glasses'",
                 "PHOTO_MINUS_HAS_MINUS_HEAD_MINUS_COVERING_MINUS_ASIDE_MINUS_FROM_MINUS_RELIGIOUS_MINUS_OR_MINUS_MEDICAL, 'The photo has a head covering (aside from religious or medical)'",
                 "PHOTO_MINUS_HAS_MINUS_RED_MINUS_EYE_MINUS_GLARE_MINUS_OR_MINUS_SHADOWS_MINUS_OVER_MINUS_FACE, 'The photo has ''red-eye'', glare or shadows over face'",
-                "OTHER, 'Other'"
             ]
         )
         fun `should map enums to human readable messages in English`(
@@ -115,7 +112,6 @@ class PhotoRejectionReasonMapperTest {
                 "WEARING_MINUS_SUNGLASSES_MINUS_OR_MINUS_TINTED_MINUS_GLASSES, 'Gwisgo sbectol haul, neu sbectol arlliw'",
                 "PHOTO_MINUS_HAS_MINUS_HEAD_MINUS_COVERING_MINUS_ASIDE_MINUS_FROM_MINUS_RELIGIOUS_MINUS_OR_MINUS_MEDICAL, 'Mae gan y llun orchudd pen (ar wahân i orchudd crefyddol neu feddygol)'",
                 "PHOTO_MINUS_HAS_MINUS_RED_MINUS_EYE_MINUS_GLARE_MINUS_OR_MINUS_SHADOWS_MINUS_OVER_MINUS_FACE, 'Mae gan y llun ''lygad coch'', llacharedd neu gysgodion dros yr wyneb'",
-                "OTHER, 'Eraill'"
             ]
         )
         fun `should map enums to human readable messages in Welsh`(

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/PhotoResubmissionTemplatePreviewDtoMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/PhotoResubmissionTemplatePreviewDtoMapperTest.kt
@@ -15,6 +15,7 @@ import uk.gov.dluhc.notificationsapi.dto.NotificationType
 import uk.gov.dluhc.notificationsapi.models.Language
 import uk.gov.dluhc.notificationsapi.models.PhotoRejectionReason
 import uk.gov.dluhc.notificationsapi.models.PhotoRejectionReason.NOT_MINUS_A_MINUS_PLAIN_MINUS_FACIAL_MINUS_EXPRESSION
+import uk.gov.dluhc.notificationsapi.models.PhotoRejectionReason.OTHER
 import uk.gov.dluhc.notificationsapi.models.PhotoRejectionReason.WEARING_MINUS_SUNGLASSES_MINUS_OR_MINUS_TINTED_MINUS_GLASSES
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.api.buildGeneratePhotoResubmissionTemplatePreviewRequest
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.api.buildPhotoResubmissionPersonalisationRequest
@@ -117,7 +118,8 @@ class PhotoResubmissionTemplatePreviewDtoMapperTest {
             personalisation = buildPhotoResubmissionPersonalisationRequest(
                 photoRejectionReasons = listOf(
                     NOT_MINUS_A_MINUS_PLAIN_MINUS_FACIAL_MINUS_EXPRESSION,
-                    WEARING_MINUS_SUNGLASSES_MINUS_OR_MINUS_TINTED_MINUS_GLASSES
+                    WEARING_MINUS_SUNGLASSES_MINUS_OR_MINUS_TINTED_MINUS_GLASSES,
+                    OTHER // OTHER is deliberately excluded from the photo rejection reason mapping
                 ),
                 photoRejectionNotes = "Please take a head and shoulders photo, with a plain expression, and without sunglasses. Regular prescription glasses are acceptable."
             )
@@ -129,7 +131,8 @@ class PhotoResubmissionTemplatePreviewDtoMapperTest {
 
         given(photoRejectionReasonMapper.toPhotoRejectionReasonString(any<PhotoRejectionReason>(), any())).willReturn(
             "Not a plain facial expression",
-            "Wearing sunglasses, or tinted glasses"
+            "Wearing sunglasses, or tinted glasses",
+            // a mapping from OTHER is not expected - this is by design
         )
 
         val expected = buildGeneratePhotoResubmissionTemplatePreviewDto(

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/PhotoResubmissionTemplatePreviewDtoMapper_NotificationTypeTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/PhotoResubmissionTemplatePreviewDtoMapper_NotificationTypeTest.kt
@@ -1,0 +1,218 @@
+package uk.gov.dluhc.notificationsapi.mapper
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import uk.gov.dluhc.notificationsapi.dto.LanguageDto
+import uk.gov.dluhc.notificationsapi.dto.NotificationType
+import uk.gov.dluhc.notificationsapi.dto.NotificationType.PHOTO_RESUBMISSION
+import uk.gov.dluhc.notificationsapi.dto.NotificationType.PHOTO_RESUBMISSION_WITH_REASONS
+import uk.gov.dluhc.notificationsapi.models.PhotoRejectionReason
+import uk.gov.dluhc.notificationsapi.models.PhotoRejectionReason.EYES_MINUS_NOT_MINUS_OPEN_MINUS_OR_MINUS_VISIBLE_MINUS_OR_MINUS_HAIR_MINUS_IN_MINUS_FRONT_MINUS_FACE
+import uk.gov.dluhc.notificationsapi.models.PhotoRejectionReason.NOT_MINUS_A_MINUS_PLAIN_MINUS_FACIAL_MINUS_EXPRESSION
+import uk.gov.dluhc.notificationsapi.models.PhotoRejectionReason.NOT_MINUS_FACING_MINUS_FORWARDS_MINUS_OR_MINUS_LOOKING_MINUS_AT_MINUS_THE_MINUS_CAMERA
+import uk.gov.dluhc.notificationsapi.models.PhotoRejectionReason.OTHER
+import uk.gov.dluhc.notificationsapi.models.PhotoRejectionReason.OTHER_MINUS_OBJECTS_MINUS_OR_MINUS_PEOPLE_MINUS_IN_MINUS_PHOTO
+import uk.gov.dluhc.notificationsapi.models.PhotoRejectionReason.PHOTO_MINUS_HAS_MINUS_HEAD_MINUS_COVERING_MINUS_ASIDE_MINUS_FROM_MINUS_RELIGIOUS_MINUS_OR_MINUS_MEDICAL
+import uk.gov.dluhc.notificationsapi.models.PhotoRejectionReason.PHOTO_MINUS_HAS_MINUS_RED_MINUS_EYE_MINUS_GLARE_MINUS_OR_MINUS_SHADOWS_MINUS_OVER_MINUS_FACE
+import uk.gov.dluhc.notificationsapi.models.PhotoRejectionReason.PHOTO_MINUS_NOT_MINUS_IN_MINUS_COLOUR_MINUS_DISTORTED_MINUS_OR_MINUS_TOO_MINUS_DARK
+import uk.gov.dluhc.notificationsapi.models.PhotoRejectionReason.WEARING_MINUS_SUNGLASSES_MINUS_OR_MINUS_TINTED_MINUS_GLASSES
+import uk.gov.dluhc.notificationsapi.models.SourceType.VOTER_MINUS_CARD
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.aNotificationChannel
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.aSourceType
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.api.buildGeneratePhotoResubmissionTemplatePreviewRequest
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.api.buildPhotoResubmissionPersonalisationRequest
+import java.util.stream.Stream
+
+@ExtendWith(MockitoExtension::class)
+class PhotoResubmissionTemplatePreviewDtoMapper_NotificationTypeTest {
+
+    @InjectMocks
+    private lateinit var mapper: PhotoResubmissionTemplatePreviewDtoMapperImpl
+
+    @Mock
+    private lateinit var languageMapper: LanguageMapper
+
+    @Mock
+    private lateinit var channelMapper: NotificationChannelMapper
+
+    @Mock
+    private lateinit var sourceTypeMapper: SourceTypeMapper
+
+    @Mock
+    private lateinit var photoRejectionReasonMapper: PhotoRejectionReasonMapper
+
+    companion object {
+        @JvmStatic
+        fun photoRejectionReasons_to_NotificationType(): Stream<Arguments> {
+            return Stream.of(
+                Arguments.of(emptyList<PhotoRejectionReason>(), PHOTO_RESUBMISSION),
+                Arguments.of(listOf(OTHER), PHOTO_RESUBMISSION),
+                Arguments.of(listOf(OTHER), PHOTO_RESUBMISSION),
+
+                Arguments.of(
+                    listOf(
+                        NOT_MINUS_FACING_MINUS_FORWARDS_MINUS_OR_MINUS_LOOKING_MINUS_AT_MINUS_THE_MINUS_CAMERA
+                    ),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(PHOTO_MINUS_NOT_MINUS_IN_MINUS_COLOUR_MINUS_DISTORTED_MINUS_OR_MINUS_TOO_MINUS_DARK),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(OTHER_MINUS_OBJECTS_MINUS_OR_MINUS_PEOPLE_MINUS_IN_MINUS_PHOTO),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(NOT_MINUS_A_MINUS_PLAIN_MINUS_FACIAL_MINUS_EXPRESSION),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(
+                        EYES_MINUS_NOT_MINUS_OPEN_MINUS_OR_MINUS_VISIBLE_MINUS_OR_MINUS_HAIR_MINUS_IN_MINUS_FRONT_MINUS_FACE
+                    ),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(WEARING_MINUS_SUNGLASSES_MINUS_OR_MINUS_TINTED_MINUS_GLASSES),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(
+                        PHOTO_MINUS_HAS_MINUS_HEAD_MINUS_COVERING_MINUS_ASIDE_MINUS_FROM_MINUS_RELIGIOUS_MINUS_OR_MINUS_MEDICAL
+                    ),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(
+                        PHOTO_MINUS_HAS_MINUS_RED_MINUS_EYE_MINUS_GLARE_MINUS_OR_MINUS_SHADOWS_MINUS_OVER_MINUS_FACE
+                    ),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+
+                Arguments.of(
+                    listOf(
+                        OTHER,
+                        NOT_MINUS_FACING_MINUS_FORWARDS_MINUS_OR_MINUS_LOOKING_MINUS_AT_MINUS_THE_MINUS_CAMERA
+                    ),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(
+                        OTHER,
+                        PHOTO_MINUS_NOT_MINUS_IN_MINUS_COLOUR_MINUS_DISTORTED_MINUS_OR_MINUS_TOO_MINUS_DARK
+                    ),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(
+                        OTHER,
+                        OTHER_MINUS_OBJECTS_MINUS_OR_MINUS_PEOPLE_MINUS_IN_MINUS_PHOTO
+                    ),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(
+                        OTHER,
+                        NOT_MINUS_A_MINUS_PLAIN_MINUS_FACIAL_MINUS_EXPRESSION
+                    ),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(
+                        OTHER,
+                        EYES_MINUS_NOT_MINUS_OPEN_MINUS_OR_MINUS_VISIBLE_MINUS_OR_MINUS_HAIR_MINUS_IN_MINUS_FRONT_MINUS_FACE
+                    ),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(
+                        OTHER,
+                        WEARING_MINUS_SUNGLASSES_MINUS_OR_MINUS_TINTED_MINUS_GLASSES
+                    ),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(
+                        OTHER,
+                        PHOTO_MINUS_HAS_MINUS_HEAD_MINUS_COVERING_MINUS_ASIDE_MINUS_FROM_MINUS_RELIGIOUS_MINUS_OR_MINUS_MEDICAL
+                    ),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(
+                        OTHER,
+                        PHOTO_MINUS_HAS_MINUS_RED_MINUS_EYE_MINUS_GLARE_MINUS_OR_MINUS_SHADOWS_MINUS_OVER_MINUS_FACE
+                    ),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+            )
+        }
+    }
+    @ParameterizedTest
+    @MethodSource("photoRejectionReasons_to_NotificationType")
+    fun `should map photo template request to dto with correct NotificationType mapping given rejection reasons and no rejection notes`(
+        photoRejectionReasons: List<PhotoRejectionReason>,
+        expectedNotificationType: NotificationType,
+    ) {
+        // Given
+        val request = buildGeneratePhotoResubmissionTemplatePreviewRequest(
+            sourceType = VOTER_MINUS_CARD,
+            personalisation = buildPhotoResubmissionPersonalisationRequest(
+                photoRejectionReasons = photoRejectionReasons,
+                photoRejectionNotes = null
+            )
+        )
+
+        given(languageMapper.fromApiToDto(any())).willReturn(LanguageDto.ENGLISH)
+        given(channelMapper.fromApiToDto(any())).willReturn(aNotificationChannel())
+        given(sourceTypeMapper.fromApiToDto(any())).willReturn(aSourceType())
+
+        // When
+        val actual = mapper.toPhotoResubmissionTemplatePreviewDto(request)
+
+        // Then
+        assertThat(actual.notificationType).isEqualTo(expectedNotificationType)
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            ", PHOTO_RESUBMISSION",
+            "'', PHOTO_RESUBMISSION",
+            "'Some rejection reason notes', PHOTO_RESUBMISSION_WITH_REASONS",
+        ]
+    )
+    fun `should map photo template request to dto with correct NotificationType mapping given no rejection reasons and rejection notes`(
+        photoRejectionNotes: String?,
+        expectedNotificationType: NotificationType,
+    ) {
+        // Given
+        val request = buildGeneratePhotoResubmissionTemplatePreviewRequest(
+            sourceType = VOTER_MINUS_CARD,
+            personalisation = buildPhotoResubmissionPersonalisationRequest(
+                photoRejectionReasons = emptyList(),
+                photoRejectionNotes = photoRejectionNotes
+            )
+        )
+
+        given(languageMapper.fromApiToDto(any())).willReturn(LanguageDto.ENGLISH)
+        given(channelMapper.fromApiToDto(any())).willReturn(aNotificationChannel())
+        given(sourceTypeMapper.fromApiToDto(any())).willReturn(aSourceType())
+
+        // When
+        val actual = mapper.toPhotoResubmissionTemplatePreviewDto(request)
+
+        // Then
+        assertThat(actual.notificationType).isEqualTo(expectedNotificationType)
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/SendNotifyMessageMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/SendNotifyMessageMapperTest.kt
@@ -31,7 +31,6 @@ import uk.gov.dluhc.notificationsapi.messaging.models.SendNotifyApplicationRecei
 import uk.gov.dluhc.notificationsapi.messaging.models.SendNotifyApplicationRejectedMessage
 import uk.gov.dluhc.notificationsapi.messaging.models.SendNotifyIdDocumentRequiredMessage
 import uk.gov.dluhc.notificationsapi.messaging.models.SendNotifyIdDocumentResubmissionMessage
-import uk.gov.dluhc.notificationsapi.messaging.models.SendNotifyPhotoResubmissionMessage
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aGssCode
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aRequestor
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aSourceReference
@@ -43,6 +42,7 @@ import uk.gov.dluhc.notificationsapi.testsupport.testdata.messaging.models.build
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.messaging.models.buildIdDocumentPersonalisationMessage
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.messaging.models.buildIdDocumentRequiredPersonalisationMessage
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.messaging.models.buildPhotoPersonalisationMessage
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.messaging.models.buildSendNotifyPhotoResubmissionMessage
 import uk.gov.dluhc.notificationsapi.messaging.models.NotificationChannel as SqsChannel
 import uk.gov.dluhc.notificationsapi.messaging.models.SourceType as SqsSourceType
 
@@ -81,7 +81,8 @@ internal class SendNotifyMessageMapperTest {
             val expectedSourceType = SourceType.VOTER_CARD
             val expectedNotificationType = PHOTO_RESUBMISSION
             val personalisationMessage = buildPhotoPersonalisationMessage(
-                photoRejectionReasons = emptyList()
+                photoRejectionReasons = emptyList(),
+                photoRejectionNotes = null
             )
             val expectedLanguage = LanguageDto.ENGLISH
 
@@ -90,14 +91,13 @@ internal class SendNotifyMessageMapperTest {
             given(notificationDestinationDtoMapper.toNotificationDestinationDto(any())).willReturn(expectedToAddress)
             given(notificationChannelMapper.fromMessagingApiToDto(any())).willReturn(expectedChannel)
 
-            val request = SendNotifyPhotoResubmissionMessage(
+            val request = buildSendNotifyPhotoResubmissionMessage(
                 channel = SqsChannel.EMAIL,
                 language = Language.EN,
                 sourceType = SqsSourceType.VOTER_MINUS_CARD,
                 sourceReference = sourceReference,
                 gssCode = gssCode,
                 requestor = requestor,
-                messageType = MessageType.PHOTO_MINUS_RESUBMISSION,
                 toAddress = toAddress,
                 personalisation = personalisationMessage,
             )
@@ -131,7 +131,7 @@ internal class SendNotifyMessageMapperTest {
             val expectedSourceType = SourceType.VOTER_CARD
             val expectedNotificationType = PHOTO_RESUBMISSION_WITH_REASONS
             val personalisationMessage = buildPhotoPersonalisationMessage(
-                photoRejectionReasons = listOf(PhotoRejectionReason.OTHER)
+                photoRejectionReasons = listOf(PhotoRejectionReason.OTHER_MINUS_OBJECTS_MINUS_OR_MINUS_PEOPLE_MINUS_IN_MINUS_PHOTO)
             )
             val expectedLanguage = LanguageDto.ENGLISH
 
@@ -140,14 +140,13 @@ internal class SendNotifyMessageMapperTest {
             given(notificationDestinationDtoMapper.toNotificationDestinationDto(any())).willReturn(expectedToAddress)
             given(notificationChannelMapper.fromMessagingApiToDto(any())).willReturn(expectedChannel)
 
-            val request = SendNotifyPhotoResubmissionMessage(
+            val request = buildSendNotifyPhotoResubmissionMessage(
                 channel = SqsChannel.EMAIL,
                 language = Language.EN,
                 sourceType = SqsSourceType.VOTER_MINUS_CARD,
                 sourceReference = sourceReference,
                 gssCode = gssCode,
                 requestor = requestor,
-                messageType = MessageType.PHOTO_MINUS_RESUBMISSION,
                 toAddress = toAddress,
                 personalisation = personalisationMessage,
             )

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/SendNotifyMessageMapper_NotificationTypeTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/SendNotifyMessageMapper_NotificationTypeTest.kt
@@ -1,0 +1,219 @@
+package uk.gov.dluhc.notificationsapi.messaging.mapper
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import uk.gov.dluhc.notificationsapi.dto.LanguageDto.ENGLISH
+import uk.gov.dluhc.notificationsapi.dto.NotificationType
+import uk.gov.dluhc.notificationsapi.dto.NotificationType.PHOTO_RESUBMISSION
+import uk.gov.dluhc.notificationsapi.dto.NotificationType.PHOTO_RESUBMISSION_WITH_REASONS
+import uk.gov.dluhc.notificationsapi.mapper.LanguageMapper
+import uk.gov.dluhc.notificationsapi.mapper.NotificationChannelMapper
+import uk.gov.dluhc.notificationsapi.mapper.NotificationTypeMapper
+import uk.gov.dluhc.notificationsapi.mapper.SourceTypeMapper
+import uk.gov.dluhc.notificationsapi.messaging.models.PhotoRejectionReason
+import uk.gov.dluhc.notificationsapi.messaging.models.PhotoRejectionReason.EYES_MINUS_NOT_MINUS_OPEN_MINUS_OR_MINUS_VISIBLE_MINUS_OR_MINUS_HAIR_MINUS_IN_MINUS_FRONT_MINUS_FACE
+import uk.gov.dluhc.notificationsapi.messaging.models.PhotoRejectionReason.NOT_MINUS_A_MINUS_PLAIN_MINUS_FACIAL_MINUS_EXPRESSION
+import uk.gov.dluhc.notificationsapi.messaging.models.PhotoRejectionReason.NOT_MINUS_FACING_MINUS_FORWARDS_MINUS_OR_MINUS_LOOKING_MINUS_AT_MINUS_THE_MINUS_CAMERA
+import uk.gov.dluhc.notificationsapi.messaging.models.PhotoRejectionReason.OTHER
+import uk.gov.dluhc.notificationsapi.messaging.models.PhotoRejectionReason.OTHER_MINUS_OBJECTS_MINUS_OR_MINUS_PEOPLE_MINUS_IN_MINUS_PHOTO
+import uk.gov.dluhc.notificationsapi.messaging.models.PhotoRejectionReason.PHOTO_MINUS_HAS_MINUS_HEAD_MINUS_COVERING_MINUS_ASIDE_MINUS_FROM_MINUS_RELIGIOUS_MINUS_OR_MINUS_MEDICAL
+import uk.gov.dluhc.notificationsapi.messaging.models.PhotoRejectionReason.PHOTO_MINUS_HAS_MINUS_RED_MINUS_EYE_MINUS_GLARE_MINUS_OR_MINUS_SHADOWS_MINUS_OVER_MINUS_FACE
+import uk.gov.dluhc.notificationsapi.messaging.models.PhotoRejectionReason.PHOTO_MINUS_NOT_MINUS_IN_MINUS_COLOUR_MINUS_DISTORTED_MINUS_OR_MINUS_TOO_MINUS_DARK
+import uk.gov.dluhc.notificationsapi.messaging.models.PhotoRejectionReason.WEARING_MINUS_SUNGLASSES_MINUS_OR_MINUS_TINTED_MINUS_GLASSES
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.aNotificationChannel
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.aSourceType
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotificationDestination
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.messaging.models.buildPhotoPersonalisationMessage
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.messaging.models.buildSendNotifyPhotoResubmissionMessage
+import java.util.stream.Stream
+
+@ExtendWith(MockitoExtension::class)
+internal class SendNotifyMessageMapper_NotificationTypeTest {
+
+    @InjectMocks
+    private lateinit var mapper: SendNotifyMessageMapperImpl
+
+    @Mock
+    private lateinit var languageMapper: LanguageMapper
+
+    @Mock
+    private lateinit var notificationChannelMapper: NotificationChannelMapper
+
+    @Mock
+    private lateinit var notificationTypeMapper: NotificationTypeMapper
+
+    @Mock
+    private lateinit var sourceTypeMapper: SourceTypeMapper
+
+    @Mock
+    private lateinit var notificationDestinationDtoMapper: NotificationDestinationDtoMapper
+
+    companion object {
+        @JvmStatic
+        fun photoRejectionReasons_to_NotificationType(): Stream<Arguments> {
+            return Stream.of(
+                Arguments.of(emptyList<PhotoRejectionReason>(), PHOTO_RESUBMISSION),
+                Arguments.of(listOf(OTHER), PHOTO_RESUBMISSION),
+                Arguments.of(listOf(OTHER), PHOTO_RESUBMISSION),
+
+                Arguments.of(
+                    listOf(
+                        NOT_MINUS_FACING_MINUS_FORWARDS_MINUS_OR_MINUS_LOOKING_MINUS_AT_MINUS_THE_MINUS_CAMERA
+                    ),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(PHOTO_MINUS_NOT_MINUS_IN_MINUS_COLOUR_MINUS_DISTORTED_MINUS_OR_MINUS_TOO_MINUS_DARK),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(OTHER_MINUS_OBJECTS_MINUS_OR_MINUS_PEOPLE_MINUS_IN_MINUS_PHOTO),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(NOT_MINUS_A_MINUS_PLAIN_MINUS_FACIAL_MINUS_EXPRESSION),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(
+                        EYES_MINUS_NOT_MINUS_OPEN_MINUS_OR_MINUS_VISIBLE_MINUS_OR_MINUS_HAIR_MINUS_IN_MINUS_FRONT_MINUS_FACE
+                    ),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(WEARING_MINUS_SUNGLASSES_MINUS_OR_MINUS_TINTED_MINUS_GLASSES),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(
+                        PHOTO_MINUS_HAS_MINUS_HEAD_MINUS_COVERING_MINUS_ASIDE_MINUS_FROM_MINUS_RELIGIOUS_MINUS_OR_MINUS_MEDICAL
+                    ),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(
+                        PHOTO_MINUS_HAS_MINUS_RED_MINUS_EYE_MINUS_GLARE_MINUS_OR_MINUS_SHADOWS_MINUS_OVER_MINUS_FACE
+                    ),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+
+                Arguments.of(
+                    listOf(
+                        OTHER,
+                        NOT_MINUS_FACING_MINUS_FORWARDS_MINUS_OR_MINUS_LOOKING_MINUS_AT_MINUS_THE_MINUS_CAMERA
+                    ),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(
+                        OTHER,
+                        PHOTO_MINUS_NOT_MINUS_IN_MINUS_COLOUR_MINUS_DISTORTED_MINUS_OR_MINUS_TOO_MINUS_DARK
+                    ),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(OTHER, OTHER_MINUS_OBJECTS_MINUS_OR_MINUS_PEOPLE_MINUS_IN_MINUS_PHOTO),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(OTHER, NOT_MINUS_A_MINUS_PLAIN_MINUS_FACIAL_MINUS_EXPRESSION),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(
+                        OTHER,
+                        EYES_MINUS_NOT_MINUS_OPEN_MINUS_OR_MINUS_VISIBLE_MINUS_OR_MINUS_HAIR_MINUS_IN_MINUS_FRONT_MINUS_FACE
+                    ),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(OTHER, WEARING_MINUS_SUNGLASSES_MINUS_OR_MINUS_TINTED_MINUS_GLASSES),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(
+                        OTHER,
+                        PHOTO_MINUS_HAS_MINUS_HEAD_MINUS_COVERING_MINUS_ASIDE_MINUS_FROM_MINUS_RELIGIOUS_MINUS_OR_MINUS_MEDICAL
+                    ),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(
+                        OTHER,
+                        PHOTO_MINUS_HAS_MINUS_RED_MINUS_EYE_MINUS_GLARE_MINUS_OR_MINUS_SHADOWS_MINUS_OVER_MINUS_FACE
+                    ),
+                    PHOTO_RESUBMISSION_WITH_REASONS
+                ),
+            )
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("photoRejectionReasons_to_NotificationType")
+    fun `should map SQS SendNotifyPhotoResubmissionMessage to SendNotificationRequestDto with correct NotificationType mapping given rejection reasons and no rejection notes`(
+        photoRejectionReasons: List<PhotoRejectionReason>,
+        expectedNotificationType: NotificationType,
+    ) {
+        // Given
+        val request = buildSendNotifyPhotoResubmissionMessage(
+            personalisation = buildPhotoPersonalisationMessage(
+                photoRejectionReasons = photoRejectionReasons,
+                photoRejectionNotes = null
+            )
+        )
+
+        given(languageMapper.fromMessageToDto(any())).willReturn(ENGLISH)
+        given(sourceTypeMapper.fromMessageToDto(any())).willReturn(aSourceType())
+        given(notificationDestinationDtoMapper.toNotificationDestinationDto(any()))
+            .willReturn(aNotificationDestination())
+        given(notificationChannelMapper.fromMessagingApiToDto(any())).willReturn(aNotificationChannel())
+
+        // When
+        val notification = mapper.fromPhotoMessageToSendNotificationRequestDto(request)
+
+        // Then
+        assertThat(notification.notificationType).isEqualTo(expectedNotificationType)
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            ", PHOTO_RESUBMISSION",
+            "'', PHOTO_RESUBMISSION",
+            "'Some rejection reason notes', PHOTO_RESUBMISSION_WITH_REASONS",
+        ]
+    )
+    fun `should map SQS SendNotifyPhotoResubmissionMessage to SendNotificationRequestDto with correct NotificationType mapping given no rejection reasons and rejection notes`(
+        photoRejectionNotes: String?,
+        expectedNotificationType: NotificationType,
+    ) {
+        // Given
+        val request = buildSendNotifyPhotoResubmissionMessage(
+            personalisation = buildPhotoPersonalisationMessage(
+                photoRejectionReasons = emptyList(),
+                photoRejectionNotes = photoRejectionNotes
+            )
+        )
+
+        given(languageMapper.fromMessageToDto(any())).willReturn(ENGLISH)
+        given(sourceTypeMapper.fromMessageToDto(any())).willReturn(aSourceType())
+        given(notificationDestinationDtoMapper.toNotificationDestinationDto(any()))
+            .willReturn(aNotificationDestination())
+        given(notificationChannelMapper.fromMessagingApiToDto(any())).willReturn(aNotificationChannel())
+
+        // When
+        val notification = mapper.fromPhotoMessageToSendNotificationRequestDto(request)
+
+        // Then
+        assertThat(notification.notificationType).isEqualTo(expectedNotificationType)
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/TemplatePersonalisationMessageMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/TemplatePersonalisationMessageMapperTest.kt
@@ -77,13 +77,15 @@ internal class TemplatePersonalisationMessageMapperTest {
             val personalisationMessage = buildPhotoPersonalisationMessage(
                 photoRejectionReasons = listOf(
                     NOT_MINUS_A_MINUS_PLAIN_MINUS_FACIAL_MINUS_EXPRESSION,
-                    WEARING_MINUS_SUNGLASSES_MINUS_OR_MINUS_TINTED_MINUS_GLASSES
+                    WEARING_MINUS_SUNGLASSES_MINUS_OR_MINUS_TINTED_MINUS_GLASSES,
+                    PhotoRejectionReason.OTHER // OTHER is deliberately excluded from the photo rejection reason mapping
                 ),
                 photoRejectionNotes = "Please take a head and shoulders photo, with a plain expression, and without sunglasses. Regular prescription glasses are acceptable."
             )
             val photoRejectionReasons: List<String> = listOf(
                 "Not a plain facial expression",
-                "Wearing sunglasses, or tinted glasses"
+                "Wearing sunglasses, or tinted glasses",
+                // a mapping from OTHER is not expected - this is by design
             )
             val expectedPersonalisationDto = buildPhotoPersonalisationDtoFromMessage(
                 personalisationMessage,

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GeneratePhotoResubmissionTemplatePreviewIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GeneratePhotoResubmissionTemplatePreviewIntegrationTest.kt
@@ -208,7 +208,7 @@ internal class GeneratePhotoResubmissionTemplatePreviewIntegrationTest : Integra
               "personalisation": {
                 "applicationReference": "A3JSZC4CRH",
                 "firstName": "Fred",
-                "photoRejectionReasons": ["other"],
+                "photoRejectionReasons": ["other-objects-or-people-in-photo"],
                 "photoRequestFreeText": "Please provide a clear image",
                 "uploadPhotoLink": "photo-398c1be2-7950-48a2-aca8-14cb9276a673",
                 "eroContactDetails": {
@@ -232,7 +232,7 @@ internal class GeneratePhotoResubmissionTemplatePreviewIntegrationTest : Integra
         val expectedPersonalisationDataMap = mapOf(
             "applicationReference" to "A3JSZC4CRH",
             "firstName" to "Fred",
-            "photoRejectionReasons" to listOf("Other"),
+            "photoRejectionReasons" to listOf("There are other people or objects in the photo"),
             "photoRejectionNotes" to "",
             "photoRequestFreeText" to "Please provide a clear image",
             "uploadPhotoLink" to "photo-398c1be2-7950-48a2-aca8-14cb9276a673",
@@ -276,7 +276,7 @@ internal class GeneratePhotoResubmissionTemplatePreviewIntegrationTest : Integra
             mapOf(
                 "applicationReference" to applicationReference,
                 "firstName" to firstName,
-                "photoRejectionReasons" to listOf("Other"),
+                "photoRejectionReasons" to listOf("There are other people or objects in the photo"),
                 "photoRejectionNotes" to (photoRejectionNotes ?: ""),
                 "photoRequestFreeText" to photoRequestFreeText,
                 "uploadPhotoLink" to uploadPhotoLink,
@@ -327,7 +327,7 @@ internal class GeneratePhotoResubmissionTemplatePreviewIntegrationTest : Integra
             mapOf(
                 "applicationReference" to applicationReference,
                 "firstName" to firstName,
-                "photoRejectionReasons" to listOf("Other"),
+                "photoRejectionReasons" to listOf("There are other people or objects in the photo"),
                 "photoRejectionNotes" to (photoRejectionNotes ?: ""),
                 "photoRequestFreeText" to photoRequestFreeText,
                 "uploadPhotoLink" to uploadPhotoLink,

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/api/ResubmissionPersonalisationRequestBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/api/ResubmissionPersonalisationRequestBuilder.kt
@@ -12,7 +12,7 @@ import uk.gov.dluhc.notificationsapi.testsupport.testdata.getAValidPostcode
 fun buildPhotoResubmissionPersonalisationRequest(
     applicationReference: String = aValidApplicationReference(),
     firstName: String = DataFaker.faker.name().firstName(),
-    photoRejectionReasons: List<PhotoRejectionReason> = listOf(PhotoRejectionReason.OTHER),
+    photoRejectionReasons: List<PhotoRejectionReason> = listOf(PhotoRejectionReason.OTHER_MINUS_OBJECTS_MINUS_OR_MINUS_PEOPLE_MINUS_IN_MINUS_PHOTO),
     photoRejectionNotes: String? = DataFaker.faker.harryPotter().spell(),
     photoRequestFreeText: String = DataFaker.faker.harryPotter().spell(),
     uploadPhotoLink: String = "http://localhost:8080/eros/photo/398c1be2-7950-48a2-aca8-14cb9276a673",


### PR DESCRIPTION
This PR adds logic to ensure OTHER is removed from photo rejection list and not used to drive template decision.

Basically there are 2 gov uk notify templates for photo resubmission:
`PHOTO_RESUBMISSION` (the original one)
and
`PHOTO_RESUBMISSION_WITH_REASONS`

The new `PHOTO_RESUBMISSION_WITH_REASONS` template should be used if there are photo rejection reasons (excluding `OTHER`), OR there are photo rejection reason notes. Otherwise we should use original `PHOTO_RESUBMISSION` template.

Over and above the selection of the template, if the photo rejections reasons contains `OTHER` (in addition to other rejection reasons), the rendered template must not include "other" in the bulleted list.

Basically `OTHER` is relevant to VCA and the vc-admin, but should not be used as part of the notifications template selection or rendered template sent to the elector.

I could have chosen to filter `OTHER` from the list before VCA sends it to notifications-api .... but I'd still need to make most of the changes I've made here, plus I'm not confident that the business wont change their mind sometime soon! ¯\_(ツ)_/¯ 

