### PR TITLE
EIP1-6179 - Bump logging-library version; Use messaging-support-library

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,7 +67,8 @@ dependencies {
     kapt("org.mapstruct:mapstruct-processor:1.5.3.Final")
 
     // internal libs
-    implementation("uk.gov.dluhc:logging-library:0.0.2")
+    implementation("uk.gov.dluhc:logging-library:2.2.0")
+    implementation("uk.gov.dluhc:messaging-support-library:1.0.0")
 
     // api
     implementation("org.springframework.boot:spring-boot-starter-actuator")

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/MessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/MessageListener.kt
@@ -1,5 +1,0 @@
-package uk.gov.dluhc.notificationsapi.messaging
-
-interface MessageListener<PAYLOAD> {
-    fun handleMessage(payload: PAYLOAD)
-}

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/RemoveApplicationNotificationsMessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/RemoveApplicationNotificationsMessageListener.kt
@@ -4,6 +4,7 @@ import io.awspring.cloud.messaging.listener.annotation.SqsListener
 import mu.KotlinLogging
 import org.springframework.messaging.handler.annotation.Payload
 import org.springframework.stereotype.Component
+import uk.gov.dluhc.messagingsupport.MessageListener
 import uk.gov.dluhc.notificationsapi.messaging.mapper.RemoveNotificationsMapper
 import uk.gov.dluhc.notificationsapi.messaging.models.RemoveApplicationNotificationsMessage
 import uk.gov.dluhc.notificationsapi.service.RemoveNotificationsService

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyApplicationApprovedMessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyApplicationApprovedMessageListener.kt
@@ -4,6 +4,7 @@ import io.awspring.cloud.messaging.listener.annotation.SqsListener
 import mu.KotlinLogging
 import org.springframework.messaging.handler.annotation.Payload
 import org.springframework.stereotype.Component
+import uk.gov.dluhc.messagingsupport.MessageListener
 import uk.gov.dluhc.notificationsapi.mapper.TemplatePersonalisationDtoMapper
 import uk.gov.dluhc.notificationsapi.messaging.mapper.SendNotifyMessageMapper
 import uk.gov.dluhc.notificationsapi.messaging.mapper.TemplatePersonalisationMessageMapper

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyApplicationReceivedMessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyApplicationReceivedMessageListener.kt
@@ -4,6 +4,7 @@ import io.awspring.cloud.messaging.listener.annotation.SqsListener
 import mu.KotlinLogging
 import org.springframework.messaging.handler.annotation.Payload
 import org.springframework.stereotype.Component
+import uk.gov.dluhc.messagingsupport.MessageListener
 import uk.gov.dluhc.notificationsapi.mapper.TemplatePersonalisationDtoMapper
 import uk.gov.dluhc.notificationsapi.messaging.mapper.SendNotifyMessageMapper
 import uk.gov.dluhc.notificationsapi.messaging.mapper.TemplatePersonalisationMessageMapper

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyApplicationRejectedMessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyApplicationRejectedMessageListener.kt
@@ -4,6 +4,7 @@ import io.awspring.cloud.messaging.listener.annotation.SqsListener
 import mu.KotlinLogging
 import org.springframework.messaging.handler.annotation.Payload
 import org.springframework.stereotype.Component
+import uk.gov.dluhc.messagingsupport.MessageListener
 import uk.gov.dluhc.notificationsapi.mapper.TemplatePersonalisationDtoMapper
 import uk.gov.dluhc.notificationsapi.messaging.mapper.SendNotifyMessageMapper
 import uk.gov.dluhc.notificationsapi.messaging.mapper.TemplatePersonalisationMessageMapper

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyIdDocumentRequiredMessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyIdDocumentRequiredMessageListener.kt
@@ -4,6 +4,7 @@ import io.awspring.cloud.messaging.listener.annotation.SqsListener
 import mu.KotlinLogging
 import org.springframework.messaging.handler.annotation.Payload
 import org.springframework.stereotype.Component
+import uk.gov.dluhc.messagingsupport.MessageListener
 import uk.gov.dluhc.notificationsapi.mapper.TemplatePersonalisationDtoMapper
 import uk.gov.dluhc.notificationsapi.messaging.mapper.SendNotifyMessageMapper
 import uk.gov.dluhc.notificationsapi.messaging.mapper.TemplatePersonalisationMessageMapper

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyIdDocumentResubmissionMessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyIdDocumentResubmissionMessageListener.kt
@@ -4,6 +4,7 @@ import io.awspring.cloud.messaging.listener.annotation.SqsListener
 import mu.KotlinLogging
 import org.springframework.messaging.handler.annotation.Payload
 import org.springframework.stereotype.Component
+import uk.gov.dluhc.messagingsupport.MessageListener
 import uk.gov.dluhc.notificationsapi.mapper.TemplatePersonalisationDtoMapper
 import uk.gov.dluhc.notificationsapi.messaging.mapper.SendNotifyMessageMapper
 import uk.gov.dluhc.notificationsapi.messaging.mapper.TemplatePersonalisationMessageMapper

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyPhotoResubmissionMessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyPhotoResubmissionMessageListener.kt
@@ -4,6 +4,7 @@ import io.awspring.cloud.messaging.listener.annotation.SqsListener
 import mu.KotlinLogging
 import org.springframework.messaging.handler.annotation.Payload
 import org.springframework.stereotype.Component
+import uk.gov.dluhc.messagingsupport.MessageListener
 import uk.gov.dluhc.notificationsapi.mapper.TemplatePersonalisationDtoMapper
 import uk.gov.dluhc.notificationsapi.messaging.mapper.SendNotifyMessageMapper
 import uk.gov.dluhc.notificationsapi.messaging.mapper.TemplatePersonalisationMessageMapper


### PR DESCRIPTION
This PR bumps the version of logging-library; plus brings in and uses messaging-support-library