### PR TITLE
EIP1-4790 - Added `cd-issued-driving-licence` DocumentType

### DIFF
--- a/src/main/resources/openapi/NotificationsAPIs.yaml
+++ b/src/main/resources/openapi/NotificationsAPIs.yaml
@@ -1290,6 +1290,7 @@ components:
         - photocard-driving-licence
         - biometric-identity-document
         - ni-electoral-identity-card
+        - cd-issued-driving-licence
     DocumentRejectionReason:
       title: DocumentRejectionReason
       description: Enum of reasons why a document may be rejected

--- a/src/main/resources/openapi/sqs/Notifications-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/Notifications-sqs-messaging.yaml
@@ -563,6 +563,7 @@ components:
         - photocard-driving-licence
         - biometric-identity-document
         - ni-electoral-identity-card
+        - cd-issued-driving-licence
     DocumentRejectionReason:
       title: DocumentRejectionReason
       description: Enum of reasons why a document may be rejected


### PR DESCRIPTION
This PR adds the DocumentType `cd-issued-driving-licence` (Driving licence issued by a Crown Dependency) to the REST API and SQS specs. This is because notifications-api needs a superset of all document types etc that app APIs could send it (VCA, OAVA etc); and `cd-issued-driving-licence` that could potentially be sent by VCA was missing

I've deliberately not bumped the spec versions - whilst this is on `eip-main` its not been released yet. There have been a couple of other spec changes under this same ticket (EIP1-4790) that have already bumped the spec version. My thinking is we only need to bump the spec version once for the whole of EIP1-4790
