### PR TITLE
EIP1-4790 - Code to select the correct template ID for document resubmission comms

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/dto/ResubmissionTemplatePreviewDto.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/dto/ResubmissionTemplatePreviewDto.kt
@@ -4,12 +4,13 @@ class GenerateIdDocumentResubmissionTemplatePreviewDto(
     sourceType: SourceType,
     channel: NotificationChannel,
     language: LanguageDto,
-    val personalisation: IdDocumentPersonalisationDto
+    val personalisation: IdDocumentPersonalisationDto,
+    notificationType: NotificationType
 ) : BaseGenerateTemplatePreviewDto(
     sourceType = sourceType,
     channel = channel,
     language = language,
-    notificationType = NotificationType.ID_DOCUMENT_RESUBMISSION
+    notificationType = notificationType
 )
 
 class GeneratePhotoResubmissionTemplatePreviewDto(

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/IdentityDocumentResubmissionTemplatePreviewDtoMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/IdentityDocumentResubmissionTemplatePreviewDtoMapper.kt
@@ -1,13 +1,31 @@
 package uk.gov.dluhc.notificationsapi.mapper
 
+import org.apache.commons.lang3.StringUtils.isNotBlank
 import org.mapstruct.Mapper
+import org.mapstruct.Mapping
 import uk.gov.dluhc.notificationsapi.dto.GenerateIdDocumentResubmissionTemplatePreviewDto
+import uk.gov.dluhc.notificationsapi.dto.NotificationType
+import uk.gov.dluhc.notificationsapi.dto.NotificationType.ID_DOCUMENT_RESUBMISSION
+import uk.gov.dluhc.notificationsapi.dto.NotificationType.ID_DOCUMENT_RESUBMISSION_WITH_REASONS
 import uk.gov.dluhc.notificationsapi.models.GenerateIdDocumentResubmissionTemplatePreviewRequest
 
 @Mapper(uses = [LanguageMapper::class, NotificationChannelMapper::class, SourceTypeMapper::class])
-interface IdentityDocumentResubmissionTemplatePreviewDtoMapper {
+abstract class IdentityDocumentResubmissionTemplatePreviewDtoMapper {
 
-    fun toIdDocumentResubmissionTemplatePreviewDto(
-        request: GenerateIdDocumentResubmissionTemplatePreviewRequest
+    @Mapping(target = "notificationType", expression = "java( idDocumentResubmissionNotificationType(request) )")
+    abstract fun toIdDocumentResubmissionTemplatePreviewDto(
+        request: GenerateIdDocumentResubmissionTemplatePreviewRequest,
     ): GenerateIdDocumentResubmissionTemplatePreviewDto
+
+    protected fun idDocumentResubmissionNotificationType(request: GenerateIdDocumentResubmissionTemplatePreviewRequest): NotificationType =
+        // ID_DOCUMENT_RESUBMISSION_WITH_REASONS should be used if all rejected documents have either any rejection reasons (excluding OTHER)
+        // or has rejection notes
+        with(request.personalisation) {
+            if (!rejectedDocuments.isNullOrEmpty() &&
+                rejectedDocuments.all { it.rejectionReasonsExcludingOther.isNotEmpty() || isNotBlank(it.rejectionNotes) }
+            )
+                ID_DOCUMENT_RESUBMISSION_WITH_REASONS
+            else
+                ID_DOCUMENT_RESUBMISSION
+        }
 }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/RejectedDocumentExtensions.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/RejectedDocumentExtensions.kt
@@ -1,0 +1,13 @@
+package uk.gov.dluhc.notificationsapi.mapper
+
+import uk.gov.dluhc.notificationsapi.models.DocumentRejectionReason
+import uk.gov.dluhc.notificationsapi.models.DocumentRejectionReason.OTHER
+import uk.gov.dluhc.notificationsapi.models.RejectedDocument
+
+/**
+ * Extension property on RejectedDocument to return the document rejection reasons, excluding OTHER
+ * This is because whilst OTHER is a valid rejection reason the ERO can make, it is not to be used in the decision
+ * about which gov.uk template to use, or rendered in the bulleted list of rejection reasons in the rendered template.
+ */
+val RejectedDocument.rejectionReasonsExcludingOther: List<DocumentRejectionReason>
+    get() = this.rejectionReasons.filter { it != OTHER }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/RejectedDocumentExtensions.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/RejectedDocumentExtensions.kt
@@ -1,0 +1,13 @@
+package uk.gov.dluhc.notificationsapi.messaging.mapper
+
+import uk.gov.dluhc.notificationsapi.messaging.models.DocumentRejectionReason
+import uk.gov.dluhc.notificationsapi.messaging.models.DocumentRejectionReason.OTHER
+import uk.gov.dluhc.notificationsapi.messaging.models.RejectedDocument
+
+/**
+ * Extension property on RejectedDocument to return the document rejection reasons, excluding OTHER
+ * This is because whilst OTHER is a valid rejection reason the ERO can make, it is not to be used in the decision
+ * about which gov.uk template to use, or rendered in the bulleted list of rejection reasons in the rendered template.
+ */
+val RejectedDocument.rejectionReasonsExcludingOther: List<DocumentRejectionReason>
+    get() = this.rejectionReasons.filter { it != OTHER }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/IdentityDocumentResubmissionTemplatePreviewDtoMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/IdentityDocumentResubmissionTemplatePreviewDtoMapperTest.kt
@@ -10,12 +10,17 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
 import uk.gov.dluhc.notificationsapi.dto.LanguageDto
+import uk.gov.dluhc.notificationsapi.dto.NotificationType.ID_DOCUMENT_RESUBMISSION
+import uk.gov.dluhc.notificationsapi.dto.NotificationType.ID_DOCUMENT_RESUBMISSION_WITH_REASONS
+import uk.gov.dluhc.notificationsapi.models.DocumentRejectionReason.DOCUMENT_MINUS_TOO_MINUS_OLD
 import uk.gov.dluhc.notificationsapi.models.Language
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.api.buildGenerateIdDocumentResubmissionTemplatePreviewRequest
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.api.buildIdDocumentResubmissionPersonalisationRequest
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.buildAddressDto
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.buildContactDetailsDto
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.buildGenerateIdDocumentResubmissionTemplatePreviewDto
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.buildIdDocumentPersonalisationDto
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.models.buildRejectedDocument
 import uk.gov.dluhc.notificationsapi.dto.NotificationChannel as NotificationChannelDto
 import uk.gov.dluhc.notificationsapi.dto.SourceType as SourceTypeDto
 import uk.gov.dluhc.notificationsapi.models.NotificationChannel as NotificationChannelApi
@@ -37,12 +42,15 @@ class IdentityDocumentResubmissionTemplatePreviewDtoMapperTest {
     private lateinit var sourceTypeMapper: SourceTypeMapper
 
     @Test
-    fun `should map ID document template request to dto`() {
+    fun `should map ID document template request to dto given no rejected documents`() {
         // Given
         val request = buildGenerateIdDocumentResubmissionTemplatePreviewRequest(
             channel = NotificationChannelApi.LETTER,
             language = Language.EN,
-            sourceType = SourceTypeModel.VOTER_MINUS_CARD
+            sourceType = SourceTypeModel.VOTER_MINUS_CARD,
+            personalisation = buildIdDocumentResubmissionPersonalisationRequest(
+                rejectedDocuments = emptyList()
+            )
         )
 
         given(languageMapper.fromApiToDto(any())).willReturn(LanguageDto.ENGLISH)
@@ -53,6 +61,69 @@ class IdentityDocumentResubmissionTemplatePreviewDtoMapperTest {
             sourceType = SourceTypeDto.VOTER_CARD,
             channel = NotificationChannelDto.LETTER,
             language = LanguageDto.ENGLISH,
+            notificationType = ID_DOCUMENT_RESUBMISSION,
+            personalisation = with(request.personalisation) {
+                buildIdDocumentPersonalisationDto(
+                    applicationReference = applicationReference,
+                    firstName = firstName,
+                    idDocumentRequestFreeText = idDocumentRequestFreeText,
+                    eroContactDetails = with(eroContactDetails) {
+                        buildContactDetailsDto(
+                            localAuthorityName = localAuthorityName,
+                            website = website,
+                            phone = phone,
+                            email = email,
+                            address = with(address) {
+                                buildAddressDto(
+                                    street = street,
+                                    property = property,
+                                    locality = locality,
+                                    town = town,
+                                    area = area,
+                                    postcode = postcode
+                                )
+                            }
+                        )
+                    }
+                )
+            }
+        )
+
+        // When
+        val actual = mapper.toIdDocumentResubmissionTemplatePreviewDto(request)
+
+        // Then
+        assertThat(actual).usingRecursiveComparison().isEqualTo(expected)
+        verify(languageMapper).fromApiToDto(Language.EN)
+        verify(channelMapper).fromApiToDto(NotificationChannelApi.LETTER)
+        verify(sourceTypeMapper).fromApiToDto(SourceTypeModel.VOTER_MINUS_CARD)
+    }
+
+    @Test
+    fun `should map ID document template request to dto given rejected documents with rejection reasons`() {
+        // Given
+        val request = buildGenerateIdDocumentResubmissionTemplatePreviewRequest(
+            channel = NotificationChannelApi.LETTER,
+            language = Language.EN,
+            sourceType = SourceTypeModel.VOTER_MINUS_CARD,
+            personalisation = buildIdDocumentResubmissionPersonalisationRequest(
+                rejectedDocuments = listOf(
+                    buildRejectedDocument(
+                        rejectionReasons = listOf(DOCUMENT_MINUS_TOO_MINUS_OLD)
+                    )
+                )
+            )
+        )
+
+        given(languageMapper.fromApiToDto(any())).willReturn(LanguageDto.ENGLISH)
+        given(channelMapper.fromApiToDto(any())).willReturn(NotificationChannelDto.LETTER)
+        given(sourceTypeMapper.fromApiToDto(any())).willReturn(SourceTypeDto.VOTER_CARD)
+
+        val expected = buildGenerateIdDocumentResubmissionTemplatePreviewDto(
+            sourceType = SourceTypeDto.VOTER_CARD,
+            channel = NotificationChannelDto.LETTER,
+            language = LanguageDto.ENGLISH,
+            notificationType = ID_DOCUMENT_RESUBMISSION_WITH_REASONS,
             personalisation = with(request.personalisation) {
                 buildIdDocumentPersonalisationDto(
                     applicationReference = applicationReference,

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/IdentityDocumentResubmissionTemplatePreviewDtoMapper_NotificationTypeTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/IdentityDocumentResubmissionTemplatePreviewDtoMapper_NotificationTypeTest.kt
@@ -1,0 +1,248 @@
+package uk.gov.dluhc.notificationsapi.mapper
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import uk.gov.dluhc.notificationsapi.dto.LanguageDto
+import uk.gov.dluhc.notificationsapi.dto.NotificationType
+import uk.gov.dluhc.notificationsapi.dto.NotificationType.ID_DOCUMENT_RESUBMISSION
+import uk.gov.dluhc.notificationsapi.dto.NotificationType.ID_DOCUMENT_RESUBMISSION_WITH_REASONS
+import uk.gov.dluhc.notificationsapi.models.DocumentRejectionReason
+import uk.gov.dluhc.notificationsapi.models.DocumentRejectionReason.APPLICANT_MINUS_DETAILS_MINUS_NOT_MINUS_CLEAR
+import uk.gov.dluhc.notificationsapi.models.DocumentRejectionReason.DOCUMENT_MINUS_TOO_MINUS_OLD
+import uk.gov.dluhc.notificationsapi.models.DocumentRejectionReason.DUPLICATE_MINUS_DOCUMENT
+import uk.gov.dluhc.notificationsapi.models.DocumentRejectionReason.INVALID_MINUS_DOCUMENT_MINUS_COUNTRY
+import uk.gov.dluhc.notificationsapi.models.DocumentRejectionReason.INVALID_MINUS_DOCUMENT_MINUS_TYPE
+import uk.gov.dluhc.notificationsapi.models.DocumentRejectionReason.OTHER
+import uk.gov.dluhc.notificationsapi.models.DocumentRejectionReason.UNREADABLE_MINUS_DOCUMENT
+import uk.gov.dluhc.notificationsapi.models.Language
+import uk.gov.dluhc.notificationsapi.models.NotificationChannel
+import uk.gov.dluhc.notificationsapi.models.SourceType
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.api.buildGenerateIdDocumentResubmissionTemplatePreviewRequest
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.api.buildIdDocumentResubmissionPersonalisationRequest
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.models.buildRejectedDocument
+import java.util.stream.Stream
+
+@ExtendWith(MockitoExtension::class)
+class IdentityDocumentResubmissionTemplatePreviewDtoMapper_NotificationTypeTest {
+
+    @InjectMocks
+    private lateinit var mapper: IdentityDocumentResubmissionTemplatePreviewDtoMapperImpl
+
+    @Mock
+    private lateinit var languageMapper: LanguageMapper
+
+    @Mock
+    private lateinit var channelMapper: NotificationChannelMapper
+
+    @Mock
+    private lateinit var sourceTypeMapper: SourceTypeMapper
+
+    companion object {
+        @JvmStatic
+        fun documentRejectionReasons_to_NotificationType(): Stream<Arguments> {
+            return Stream.of(
+                Arguments.of(emptyList<DocumentRejectionReason>(), ID_DOCUMENT_RESUBMISSION),
+                Arguments.of(listOf(OTHER), ID_DOCUMENT_RESUBMISSION),
+                Arguments.of(listOf(OTHER), ID_DOCUMENT_RESUBMISSION),
+
+                Arguments.of(
+                    listOf(DOCUMENT_MINUS_TOO_MINUS_OLD),
+                    ID_DOCUMENT_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(UNREADABLE_MINUS_DOCUMENT),
+                    ID_DOCUMENT_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(INVALID_MINUS_DOCUMENT_MINUS_TYPE),
+                    ID_DOCUMENT_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(DUPLICATE_MINUS_DOCUMENT),
+                    ID_DOCUMENT_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(INVALID_MINUS_DOCUMENT_MINUS_COUNTRY),
+                    ID_DOCUMENT_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(APPLICANT_MINUS_DETAILS_MINUS_NOT_MINUS_CLEAR),
+                    ID_DOCUMENT_RESUBMISSION_WITH_REASONS
+                ),
+
+                Arguments.of(
+                    listOf(OTHER, DOCUMENT_MINUS_TOO_MINUS_OLD),
+                    ID_DOCUMENT_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(OTHER, UNREADABLE_MINUS_DOCUMENT),
+                    ID_DOCUMENT_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(OTHER, INVALID_MINUS_DOCUMENT_MINUS_TYPE),
+                    ID_DOCUMENT_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(OTHER, DUPLICATE_MINUS_DOCUMENT),
+                    ID_DOCUMENT_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(OTHER, INVALID_MINUS_DOCUMENT_MINUS_COUNTRY),
+                    ID_DOCUMENT_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(OTHER, APPLICANT_MINUS_DETAILS_MINUS_NOT_MINUS_CLEAR),
+                    ID_DOCUMENT_RESUBMISSION_WITH_REASONS
+                ),
+            )
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("documentRejectionReasons_to_NotificationType")
+    fun `should map ID document template request to dto with correct NotificationType mapping given rejection reasons and no rejection notes`(
+        documentRejectionReasons: List<DocumentRejectionReason>,
+        expectedNotificationType: NotificationType,
+    ) {
+        // Given
+        val request = buildGenerateIdDocumentResubmissionTemplatePreviewRequest(
+            channel = NotificationChannel.LETTER,
+            language = Language.EN,
+            sourceType = SourceType.VOTER_MINUS_CARD,
+            personalisation = buildIdDocumentResubmissionPersonalisationRequest(
+                rejectedDocuments = listOf(
+                    buildRejectedDocument(
+                        rejectionReasons = documentRejectionReasons,
+                        rejectionNotes = null
+                    )
+                )
+            )
+        )
+
+        given(languageMapper.fromApiToDto(any())).willReturn(LanguageDto.ENGLISH)
+        given(channelMapper.fromApiToDto(any())).willReturn(uk.gov.dluhc.notificationsapi.dto.NotificationChannel.LETTER)
+        given(sourceTypeMapper.fromApiToDto(any())).willReturn(uk.gov.dluhc.notificationsapi.dto.SourceType.VOTER_CARD)
+
+        // When
+        val actual = mapper.toIdDocumentResubmissionTemplatePreviewDto(request)
+
+        // Then
+        assertThat(actual.notificationType).isEqualTo(expectedNotificationType)
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            ", ID_DOCUMENT_RESUBMISSION",
+            "'', ID_DOCUMENT_RESUBMISSION",
+            "'Some rejection reason notes', ID_DOCUMENT_RESUBMISSION_WITH_REASONS",
+        ]
+    )
+    fun `should map ID document template request to dto with correct NotificationType mapping given document with no rejection reasons and rejection notes`(
+        documentRejectionNotes: String?,
+        expectedNotificationType: NotificationType,
+    ) {
+        // Given
+        val request = buildGenerateIdDocumentResubmissionTemplatePreviewRequest(
+            channel = NotificationChannel.LETTER,
+            language = Language.EN,
+            sourceType = SourceType.VOTER_MINUS_CARD,
+            personalisation = buildIdDocumentResubmissionPersonalisationRequest(
+                rejectedDocuments = listOf(
+                    buildRejectedDocument(
+                        rejectionReasons = emptyList(),
+                        rejectionNotes = documentRejectionNotes
+                    )
+                )
+            )
+        )
+
+        given(languageMapper.fromApiToDto(any())).willReturn(LanguageDto.ENGLISH)
+        given(channelMapper.fromApiToDto(any())).willReturn(uk.gov.dluhc.notificationsapi.dto.NotificationChannel.LETTER)
+        given(sourceTypeMapper.fromApiToDto(any())).willReturn(uk.gov.dluhc.notificationsapi.dto.SourceType.VOTER_CARD)
+
+        // When
+        val actual = mapper.toIdDocumentResubmissionTemplatePreviewDto(request)
+
+        // Then
+        assertThat(actual.notificationType).isEqualTo(expectedNotificationType)
+    }
+
+    @Test
+    fun `should map ID document template request to dto with correct NotificationType mapping given all documents have rejection reasons or rejection notes`() {
+        // Given
+        val request = buildGenerateIdDocumentResubmissionTemplatePreviewRequest(
+            channel = NotificationChannel.LETTER,
+            language = Language.EN,
+            sourceType = SourceType.VOTER_MINUS_CARD,
+            personalisation = buildIdDocumentResubmissionPersonalisationRequest(
+                rejectedDocuments = listOf(
+                    buildRejectedDocument(
+                        rejectionReasons = emptyList(),
+                        rejectionNotes = "a reason for rejecting the document"
+                    ),
+                    buildRejectedDocument(
+                        rejectionReasons = listOf(DOCUMENT_MINUS_TOO_MINUS_OLD),
+                        rejectionNotes = null
+                    )
+                )
+            )
+        )
+
+        given(languageMapper.fromApiToDto(any())).willReturn(LanguageDto.ENGLISH)
+        given(channelMapper.fromApiToDto(any())).willReturn(uk.gov.dluhc.notificationsapi.dto.NotificationChannel.LETTER)
+        given(sourceTypeMapper.fromApiToDto(any())).willReturn(uk.gov.dluhc.notificationsapi.dto.SourceType.VOTER_CARD)
+
+        // When
+        val actual = mapper.toIdDocumentResubmissionTemplatePreviewDto(request)
+
+        // Then
+        assertThat(actual.notificationType).isEqualTo(ID_DOCUMENT_RESUBMISSION_WITH_REASONS)
+    }
+
+    @Test
+    fun `should map ID document template request to dto with correct NotificationType mapping given not all documents have rejection reasons or rejection notes`() {
+        // Given
+        val request = buildGenerateIdDocumentResubmissionTemplatePreviewRequest(
+            channel = NotificationChannel.LETTER,
+            language = Language.EN,
+            sourceType = SourceType.VOTER_MINUS_CARD,
+            personalisation = buildIdDocumentResubmissionPersonalisationRequest(
+                rejectedDocuments = listOf(
+                    buildRejectedDocument(
+                        rejectionReasons = emptyList(),
+                        rejectionNotes = "a reason for rejecting the document"
+                    ),
+                    buildRejectedDocument(
+                        rejectionReasons = listOf(DOCUMENT_MINUS_TOO_MINUS_OLD),
+                        rejectionNotes = null
+                    ),
+                    buildRejectedDocument(
+                        rejectionReasons = emptyList(),
+                        rejectionNotes = null
+                    )
+                )
+            )
+        )
+
+        given(languageMapper.fromApiToDto(any())).willReturn(LanguageDto.ENGLISH)
+        given(channelMapper.fromApiToDto(any())).willReturn(uk.gov.dluhc.notificationsapi.dto.NotificationChannel.LETTER)
+        given(sourceTypeMapper.fromApiToDto(any())).willReturn(uk.gov.dluhc.notificationsapi.dto.SourceType.VOTER_CARD)
+
+        // When
+        val actual = mapper.toIdDocumentResubmissionTemplatePreviewDto(request)
+
+        // Then
+        assertThat(actual.notificationType).isEqualTo(ID_DOCUMENT_RESUBMISSION)
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/SendNotifyMessageMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/SendNotifyMessageMapperTest.kt
@@ -16,6 +16,7 @@ import uk.gov.dluhc.notificationsapi.dto.LanguageDto
 import uk.gov.dluhc.notificationsapi.dto.NotificationChannel
 import uk.gov.dluhc.notificationsapi.dto.NotificationType
 import uk.gov.dluhc.notificationsapi.dto.NotificationType.ID_DOCUMENT_RESUBMISSION
+import uk.gov.dluhc.notificationsapi.dto.NotificationType.ID_DOCUMENT_RESUBMISSION_WITH_REASONS
 import uk.gov.dluhc.notificationsapi.dto.NotificationType.PHOTO_RESUBMISSION
 import uk.gov.dluhc.notificationsapi.dto.NotificationType.PHOTO_RESUBMISSION_WITH_REASONS
 import uk.gov.dluhc.notificationsapi.dto.SourceType
@@ -23,6 +24,7 @@ import uk.gov.dluhc.notificationsapi.mapper.LanguageMapper
 import uk.gov.dluhc.notificationsapi.mapper.NotificationChannelMapper
 import uk.gov.dluhc.notificationsapi.mapper.NotificationTypeMapper
 import uk.gov.dluhc.notificationsapi.mapper.SourceTypeMapper
+import uk.gov.dluhc.notificationsapi.messaging.models.DocumentRejectionReason.DOCUMENT_MINUS_TOO_MINUS_OLD
 import uk.gov.dluhc.notificationsapi.messaging.models.Language
 import uk.gov.dluhc.notificationsapi.messaging.models.MessageType
 import uk.gov.dluhc.notificationsapi.messaging.models.PhotoRejectionReason
@@ -42,6 +44,7 @@ import uk.gov.dluhc.notificationsapi.testsupport.testdata.messaging.models.build
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.messaging.models.buildIdDocumentPersonalisationMessage
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.messaging.models.buildIdDocumentRequiredPersonalisationMessage
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.messaging.models.buildPhotoPersonalisationMessage
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.messaging.models.buildRejectedDocument
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.messaging.models.buildSendNotifyPhotoResubmissionMessage
 import uk.gov.dluhc.notificationsapi.messaging.models.NotificationChannel as SqsChannel
 import uk.gov.dluhc.notificationsapi.messaging.models.SourceType as SqsSourceType
@@ -172,7 +175,7 @@ internal class SendNotifyMessageMapperTest {
     @Nested
     inner class FromIdDocumentMessageToSendNotificationRequestDto {
         @Test
-        fun `should map SQS SendNotifyIdDocumentResubmissionMessage to SendNotificationRequestDto`() {
+        fun `should map SQS SendNotifyIdDocumentResubmissionMessage to SendNotificationRequestDto given no document rejection reasons`() {
             // Given
             val gssCode = aGssCode()
             val requestor = aRequestor()
@@ -182,11 +185,12 @@ internal class SendNotifyMessageMapperTest {
             val expectedChannel = NotificationChannel.EMAIL
             val expectedSourceType = SourceType.VOTER_CARD
             val expectedNotificationType = ID_DOCUMENT_RESUBMISSION
-            val personalisationMessage = buildIdDocumentPersonalisationMessage()
+            val personalisationMessage = buildIdDocumentPersonalisationMessage(
+                rejectedDocuments = emptyList()
+            )
             val expectedLanguage = LanguageDto.ENGLISH
 
             given(languageMapper.fromMessageToDto(any())).willReturn(expectedLanguage)
-            given(notificationTypeMapper.mapMessageTypeToNotificationType(any())).willReturn(expectedNotificationType)
             given(sourceTypeMapper.fromMessageToDto(any())).willReturn(expectedSourceType)
             given(notificationDestinationDtoMapper.toNotificationDestinationDto(any())).willReturn(expectedToAddress)
             given(notificationChannelMapper.fromMessagingApiToDto(any())).willReturn(expectedChannel)
@@ -215,7 +219,60 @@ internal class SendNotifyMessageMapperTest {
             assertThat(notification.notificationType).isEqualTo(expectedNotificationType)
             assertThat(notification.toAddress).isEqualTo(expectedToAddress)
             verify(languageMapper).fromMessageToDto(Language.EN)
-            verify(notificationTypeMapper).mapMessageTypeToNotificationType(MessageType.ID_MINUS_DOCUMENT_MINUS_RESUBMISSION)
+            verify(sourceTypeMapper).fromMessageToDto(SqsSourceType.VOTER_MINUS_CARD)
+            verify(notificationDestinationDtoMapper).toNotificationDestinationDto(toAddress)
+            verify(notificationChannelMapper).fromMessagingApiToDto(SqsChannel.EMAIL)
+        }
+
+        @Test
+        fun `should map SQS SendNotifyIdDocumentResubmissionMessage to SendNotificationRequestDto given document rejection reasons`() {
+            // Given
+            val gssCode = aGssCode()
+            val requestor = aRequestor()
+            val sourceReference = aSourceReference()
+            val toAddress = aMessageAddress()
+            val expectedToAddress = aNotificationDestination()
+            val expectedChannel = NotificationChannel.EMAIL
+            val expectedSourceType = SourceType.VOTER_CARD
+            val expectedNotificationType = ID_DOCUMENT_RESUBMISSION_WITH_REASONS
+            val personalisationMessage = buildIdDocumentPersonalisationMessage(
+                rejectedDocuments = listOf(
+                    buildRejectedDocument(
+                        rejectionReasons = listOf(DOCUMENT_MINUS_TOO_MINUS_OLD)
+                    )
+                )
+            )
+            val expectedLanguage = LanguageDto.ENGLISH
+
+            given(languageMapper.fromMessageToDto(any())).willReturn(expectedLanguage)
+            given(sourceTypeMapper.fromMessageToDto(any())).willReturn(expectedSourceType)
+            given(notificationDestinationDtoMapper.toNotificationDestinationDto(any())).willReturn(expectedToAddress)
+            given(notificationChannelMapper.fromMessagingApiToDto(any())).willReturn(expectedChannel)
+
+            val request = SendNotifyIdDocumentResubmissionMessage(
+                channel = SqsChannel.EMAIL,
+                language = Language.EN,
+                sourceType = SqsSourceType.VOTER_MINUS_CARD,
+                sourceReference = sourceReference,
+                gssCode = gssCode,
+                requestor = requestor,
+                messageType = MessageType.ID_MINUS_DOCUMENT_MINUS_RESUBMISSION,
+                toAddress = toAddress,
+                personalisation = personalisationMessage,
+            )
+
+            // When
+            val notification = mapper.fromIdDocumentMessageToSendNotificationRequestDto(request)
+
+            // Then
+            assertThat(notification.channel).isEqualTo(expectedChannel)
+            assertThat(notification.sourceType).isEqualTo(expectedSourceType)
+            assertThat(notification.sourceReference).isEqualTo(sourceReference)
+            assertThat(notification.gssCode).isEqualTo(gssCode)
+            assertThat(notification.requestor).isEqualTo(requestor)
+            assertThat(notification.notificationType).isEqualTo(expectedNotificationType)
+            assertThat(notification.toAddress).isEqualTo(expectedToAddress)
+            verify(languageMapper).fromMessageToDto(Language.EN)
             verify(sourceTypeMapper).fromMessageToDto(SqsSourceType.VOTER_MINUS_CARD)
             verify(notificationDestinationDtoMapper).toNotificationDestinationDto(toAddress)
             verify(notificationChannelMapper).fromMessagingApiToDto(SqsChannel.EMAIL)

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/SendNotifyMessageMapper_NotificationTypeTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/SendNotifyMessageMapper_NotificationTypeTest.kt
@@ -1,6 +1,8 @@
 package uk.gov.dluhc.notificationsapi.messaging.mapper
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -13,12 +15,21 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.given
 import uk.gov.dluhc.notificationsapi.dto.LanguageDto.ENGLISH
 import uk.gov.dluhc.notificationsapi.dto.NotificationType
+import uk.gov.dluhc.notificationsapi.dto.NotificationType.ID_DOCUMENT_RESUBMISSION
+import uk.gov.dluhc.notificationsapi.dto.NotificationType.ID_DOCUMENT_RESUBMISSION_WITH_REASONS
 import uk.gov.dluhc.notificationsapi.dto.NotificationType.PHOTO_RESUBMISSION
 import uk.gov.dluhc.notificationsapi.dto.NotificationType.PHOTO_RESUBMISSION_WITH_REASONS
 import uk.gov.dluhc.notificationsapi.mapper.LanguageMapper
 import uk.gov.dluhc.notificationsapi.mapper.NotificationChannelMapper
 import uk.gov.dluhc.notificationsapi.mapper.NotificationTypeMapper
 import uk.gov.dluhc.notificationsapi.mapper.SourceTypeMapper
+import uk.gov.dluhc.notificationsapi.messaging.models.DocumentRejectionReason
+import uk.gov.dluhc.notificationsapi.messaging.models.DocumentRejectionReason.APPLICANT_MINUS_DETAILS_MINUS_NOT_MINUS_CLEAR
+import uk.gov.dluhc.notificationsapi.messaging.models.DocumentRejectionReason.DOCUMENT_MINUS_TOO_MINUS_OLD
+import uk.gov.dluhc.notificationsapi.messaging.models.DocumentRejectionReason.DUPLICATE_MINUS_DOCUMENT
+import uk.gov.dluhc.notificationsapi.messaging.models.DocumentRejectionReason.INVALID_MINUS_DOCUMENT_MINUS_COUNTRY
+import uk.gov.dluhc.notificationsapi.messaging.models.DocumentRejectionReason.INVALID_MINUS_DOCUMENT_MINUS_TYPE
+import uk.gov.dluhc.notificationsapi.messaging.models.DocumentRejectionReason.UNREADABLE_MINUS_DOCUMENT
 import uk.gov.dluhc.notificationsapi.messaging.models.PhotoRejectionReason
 import uk.gov.dluhc.notificationsapi.messaging.models.PhotoRejectionReason.EYES_MINUS_NOT_MINUS_OPEN_MINUS_OR_MINUS_VISIBLE_MINUS_OR_MINUS_HAIR_MINUS_IN_MINUS_FRONT_MINUS_FACE
 import uk.gov.dluhc.notificationsapi.messaging.models.PhotoRejectionReason.NOT_MINUS_A_MINUS_PLAIN_MINUS_FACIAL_MINUS_EXPRESSION
@@ -32,7 +43,10 @@ import uk.gov.dluhc.notificationsapi.messaging.models.PhotoRejectionReason.WEARI
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aNotificationChannel
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aSourceType
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.aNotificationDestination
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.messaging.models.buildIdDocumentPersonalisationMessage
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.messaging.models.buildPhotoPersonalisationMessage
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.messaging.models.buildRejectedDocument
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.messaging.models.buildSendNotifyIdDocumentResubmissionMessage
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.messaging.models.buildSendNotifyPhotoResubmissionMessage
 import java.util.stream.Stream
 
@@ -155,65 +169,265 @@ internal class SendNotifyMessageMapper_NotificationTypeTest {
                 ),
             )
         }
+
+        @JvmStatic
+        fun documentRejectionReasons_to_NotificationType(): Stream<Arguments> {
+            return Stream.of(
+                Arguments.of(emptyList<DocumentRejectionReason>(), ID_DOCUMENT_RESUBMISSION),
+                Arguments.of(listOf(DocumentRejectionReason.OTHER), ID_DOCUMENT_RESUBMISSION),
+                Arguments.of(listOf(DocumentRejectionReason.OTHER), ID_DOCUMENT_RESUBMISSION),
+
+                Arguments.of(
+                    listOf(DOCUMENT_MINUS_TOO_MINUS_OLD),
+                    ID_DOCUMENT_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(UNREADABLE_MINUS_DOCUMENT),
+                    ID_DOCUMENT_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(INVALID_MINUS_DOCUMENT_MINUS_TYPE),
+                    ID_DOCUMENT_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(DUPLICATE_MINUS_DOCUMENT),
+                    ID_DOCUMENT_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(INVALID_MINUS_DOCUMENT_MINUS_COUNTRY),
+                    ID_DOCUMENT_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(APPLICANT_MINUS_DETAILS_MINUS_NOT_MINUS_CLEAR),
+                    ID_DOCUMENT_RESUBMISSION_WITH_REASONS
+                ),
+
+                Arguments.of(
+                    listOf(DocumentRejectionReason.OTHER, DOCUMENT_MINUS_TOO_MINUS_OLD),
+                    ID_DOCUMENT_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(DocumentRejectionReason.OTHER, UNREADABLE_MINUS_DOCUMENT),
+                    ID_DOCUMENT_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(DocumentRejectionReason.OTHER, INVALID_MINUS_DOCUMENT_MINUS_TYPE),
+                    ID_DOCUMENT_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(DocumentRejectionReason.OTHER, DUPLICATE_MINUS_DOCUMENT),
+                    ID_DOCUMENT_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(DocumentRejectionReason.OTHER, INVALID_MINUS_DOCUMENT_MINUS_COUNTRY),
+                    ID_DOCUMENT_RESUBMISSION_WITH_REASONS
+                ),
+                Arguments.of(
+                    listOf(DocumentRejectionReason.OTHER, APPLICANT_MINUS_DETAILS_MINUS_NOT_MINUS_CLEAR),
+                    ID_DOCUMENT_RESUBMISSION_WITH_REASONS
+                ),
+            )
+        }
     }
 
-    @ParameterizedTest
-    @MethodSource("photoRejectionReasons_to_NotificationType")
-    fun `should map SQS SendNotifyPhotoResubmissionMessage to SendNotificationRequestDto with correct NotificationType mapping given rejection reasons and no rejection notes`(
-        photoRejectionReasons: List<PhotoRejectionReason>,
-        expectedNotificationType: NotificationType,
-    ) {
-        // Given
-        val request = buildSendNotifyPhotoResubmissionMessage(
-            personalisation = buildPhotoPersonalisationMessage(
-                photoRejectionReasons = photoRejectionReasons,
-                photoRejectionNotes = null
+    @Nested
+    inner class FromPhotoMessageToSendNotificationRequestDto {
+        @ParameterizedTest
+        @MethodSource("uk.gov.dluhc.notificationsapi.messaging.mapper.SendNotifyMessageMapper_NotificationTypeTest#photoRejectionReasons_to_NotificationType")
+        fun `should map SQS SendNotifyPhotoResubmissionMessage to SendNotificationRequestDto with correct NotificationType mapping given rejection reasons and no rejection notes`(
+            photoRejectionReasons: List<PhotoRejectionReason>,
+            expectedNotificationType: NotificationType,
+        ) {
+            // Given
+            val request = buildSendNotifyPhotoResubmissionMessage(
+                personalisation = buildPhotoPersonalisationMessage(
+                    photoRejectionReasons = photoRejectionReasons,
+                    photoRejectionNotes = null
+                )
             )
+
+            given(languageMapper.fromMessageToDto(any())).willReturn(ENGLISH)
+            given(sourceTypeMapper.fromMessageToDto(any())).willReturn(aSourceType())
+            given(notificationDestinationDtoMapper.toNotificationDestinationDto(any()))
+                .willReturn(aNotificationDestination())
+            given(notificationChannelMapper.fromMessagingApiToDto(any())).willReturn(aNotificationChannel())
+
+            // When
+            val notification = mapper.fromPhotoMessageToSendNotificationRequestDto(request)
+
+            // Then
+            assertThat(notification.notificationType).isEqualTo(expectedNotificationType)
+        }
+
+        @ParameterizedTest
+        @CsvSource(
+            value = [
+                ", PHOTO_RESUBMISSION",
+                "'', PHOTO_RESUBMISSION",
+                "'Some rejection reason notes', PHOTO_RESUBMISSION_WITH_REASONS",
+            ]
         )
+        fun `should map SQS SendNotifyPhotoResubmissionMessage to SendNotificationRequestDto with correct NotificationType mapping given no rejection reasons and rejection notes`(
+            photoRejectionNotes: String?,
+            expectedNotificationType: NotificationType,
+        ) {
+            // Given
+            val request = buildSendNotifyPhotoResubmissionMessage(
+                personalisation = buildPhotoPersonalisationMessage(
+                    photoRejectionReasons = emptyList(),
+                    photoRejectionNotes = photoRejectionNotes
+                )
+            )
 
-        given(languageMapper.fromMessageToDto(any())).willReturn(ENGLISH)
-        given(sourceTypeMapper.fromMessageToDto(any())).willReturn(aSourceType())
-        given(notificationDestinationDtoMapper.toNotificationDestinationDto(any()))
-            .willReturn(aNotificationDestination())
-        given(notificationChannelMapper.fromMessagingApiToDto(any())).willReturn(aNotificationChannel())
+            given(languageMapper.fromMessageToDto(any())).willReturn(ENGLISH)
+            given(sourceTypeMapper.fromMessageToDto(any())).willReturn(aSourceType())
+            given(notificationDestinationDtoMapper.toNotificationDestinationDto(any()))
+                .willReturn(aNotificationDestination())
+            given(notificationChannelMapper.fromMessagingApiToDto(any())).willReturn(aNotificationChannel())
 
-        // When
-        val notification = mapper.fromPhotoMessageToSendNotificationRequestDto(request)
+            // When
+            val notification = mapper.fromPhotoMessageToSendNotificationRequestDto(request)
 
-        // Then
-        assertThat(notification.notificationType).isEqualTo(expectedNotificationType)
+            // Then
+            assertThat(notification.notificationType).isEqualTo(expectedNotificationType)
+        }
     }
 
-    @ParameterizedTest
-    @CsvSource(
-        value = [
-            ", PHOTO_RESUBMISSION",
-            "'', PHOTO_RESUBMISSION",
-            "'Some rejection reason notes', PHOTO_RESUBMISSION_WITH_REASONS",
-        ]
-    )
-    fun `should map SQS SendNotifyPhotoResubmissionMessage to SendNotificationRequestDto with correct NotificationType mapping given no rejection reasons and rejection notes`(
-        photoRejectionNotes: String?,
-        expectedNotificationType: NotificationType,
-    ) {
-        // Given
-        val request = buildSendNotifyPhotoResubmissionMessage(
-            personalisation = buildPhotoPersonalisationMessage(
-                photoRejectionReasons = emptyList(),
-                photoRejectionNotes = photoRejectionNotes
+    @Nested
+    inner class FromIdDocumentMessageToSendNotificationRequestDto {
+
+        @ParameterizedTest
+        @MethodSource("uk.gov.dluhc.notificationsapi.messaging.mapper.SendNotifyMessageMapper_NotificationTypeTest#documentRejectionReasons_to_NotificationType")
+        fun `should map ID document template request to dto with correct NotificationType mapping given rejection reasons and no rejection notes`(
+            documentRejectionReasons: List<DocumentRejectionReason>,
+            expectedNotificationType: NotificationType,
+        ) {
+            // Given
+            val request = buildSendNotifyIdDocumentResubmissionMessage(
+                personalisation = buildIdDocumentPersonalisationMessage(
+                    rejectedDocuments = listOf(
+                        buildRejectedDocument(
+                            rejectionReasons = documentRejectionReasons,
+                            rejectionNotes = null
+                        )
+                    )
+                )
             )
+
+            given(languageMapper.fromMessageToDto(any())).willReturn(ENGLISH)
+            given(sourceTypeMapper.fromMessageToDto(any())).willReturn(aSourceType())
+            given(notificationDestinationDtoMapper.toNotificationDestinationDto(any()))
+                .willReturn(aNotificationDestination())
+            given(notificationChannelMapper.fromMessagingApiToDto(any())).willReturn(aNotificationChannel())
+
+            // When
+            val actual = mapper.fromIdDocumentMessageToSendNotificationRequestDto(request)
+
+            // Then
+            assertThat(actual.notificationType).isEqualTo(expectedNotificationType)
+        }
+
+        @ParameterizedTest
+        @CsvSource(
+            value = [
+                ", ID_DOCUMENT_RESUBMISSION",
+                "'', ID_DOCUMENT_RESUBMISSION",
+                "'Some rejection reason notes', ID_DOCUMENT_RESUBMISSION_WITH_REASONS",
+            ]
         )
+        fun `should map ID document template request to dto with correct NotificationType mapping given document with no rejection reasons and rejection notes`(
+            documentRejectionNotes: String?,
+            expectedNotificationType: NotificationType,
+        ) {
+            // Given
+            val request = buildSendNotifyIdDocumentResubmissionMessage(
+                personalisation = buildIdDocumentPersonalisationMessage(
+                    rejectedDocuments = listOf(
+                        buildRejectedDocument(
+                            rejectionReasons = emptyList(),
+                            rejectionNotes = documentRejectionNotes
+                        )
+                    )
+                )
+            )
 
-        given(languageMapper.fromMessageToDto(any())).willReturn(ENGLISH)
-        given(sourceTypeMapper.fromMessageToDto(any())).willReturn(aSourceType())
-        given(notificationDestinationDtoMapper.toNotificationDestinationDto(any()))
-            .willReturn(aNotificationDestination())
-        given(notificationChannelMapper.fromMessagingApiToDto(any())).willReturn(aNotificationChannel())
+            given(languageMapper.fromMessageToDto(any())).willReturn(ENGLISH)
+            given(sourceTypeMapper.fromMessageToDto(any())).willReturn(aSourceType())
+            given(notificationDestinationDtoMapper.toNotificationDestinationDto(any()))
+                .willReturn(aNotificationDestination())
+            given(notificationChannelMapper.fromMessagingApiToDto(any())).willReturn(aNotificationChannel())
 
-        // When
-        val notification = mapper.fromPhotoMessageToSendNotificationRequestDto(request)
+            // When
+            val actual = mapper.fromIdDocumentMessageToSendNotificationRequestDto(request)
 
-        // Then
-        assertThat(notification.notificationType).isEqualTo(expectedNotificationType)
+            // Then
+            assertThat(actual.notificationType).isEqualTo(expectedNotificationType)
+        }
+
+        @Test
+        fun `should map ID document template request to dto with correct NotificationType mapping given all documents have rejection reasons or rejection notes`() {
+            // Given
+            val request = buildSendNotifyIdDocumentResubmissionMessage(
+                personalisation = buildIdDocumentPersonalisationMessage(
+                    rejectedDocuments = listOf(
+                        buildRejectedDocument(
+                            rejectionReasons = emptyList(),
+                            rejectionNotes = "a reason for rejecting the document"
+                        ),
+                        buildRejectedDocument(
+                            rejectionReasons = listOf(DOCUMENT_MINUS_TOO_MINUS_OLD),
+                            rejectionNotes = null
+                        )
+                    )
+                )
+            )
+
+            given(languageMapper.fromMessageToDto(any())).willReturn(ENGLISH)
+            given(sourceTypeMapper.fromMessageToDto(any())).willReturn(aSourceType())
+            given(notificationDestinationDtoMapper.toNotificationDestinationDto(any()))
+                .willReturn(aNotificationDestination())
+            given(notificationChannelMapper.fromMessagingApiToDto(any())).willReturn(aNotificationChannel())
+
+            // When
+            val actual = mapper.fromIdDocumentMessageToSendNotificationRequestDto(request)
+
+            // Then
+            assertThat(actual.notificationType).isEqualTo(ID_DOCUMENT_RESUBMISSION_WITH_REASONS)
+        }
+
+        @Test
+        fun `should map ID document template request to dto with correct NotificationType mapping given not all documents have rejection reasons or rejection notes`() {
+            // Given
+            val request = buildSendNotifyIdDocumentResubmissionMessage(
+                personalisation = buildIdDocumentPersonalisationMessage(
+                    rejectedDocuments = listOf(
+                        buildRejectedDocument(
+                            rejectionReasons = emptyList(),
+                            rejectionNotes = "a reason for rejecting the document"
+                        ),
+                        buildRejectedDocument(
+                            rejectionReasons = listOf(DOCUMENT_MINUS_TOO_MINUS_OLD),
+                            rejectionNotes = null
+                        ),
+                        buildRejectedDocument(
+                            rejectionReasons = emptyList(),
+                            rejectionNotes = null
+                        )
+                    )
+                )
+            )
+
+            given(languageMapper.fromMessageToDto(any())).willReturn(ENGLISH)
+            given(sourceTypeMapper.fromMessageToDto(any())).willReturn(aSourceType())
+            given(notificationDestinationDtoMapper.toNotificationDestinationDto(any()))
+                .willReturn(aNotificationDestination())
+            given(notificationChannelMapper.fromMessagingApiToDto(any())).willReturn(aNotificationChannel())
+
+            // When
+            val actual = mapper.fromIdDocumentMessageToSendNotificationRequestDto(request)
+
+            // Then
+            assertThat(actual.notificationType).isEqualTo(ID_DOCUMENT_RESUBMISSION)
+        }
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GenerateIdDocumentResubmissionTemplatePreviewIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GenerateIdDocumentResubmissionTemplatePreviewIntegrationTest.kt
@@ -26,7 +26,7 @@ import uk.gov.dluhc.notificationsapi.models.SourceType as SourceTypeModel
 internal class GenerateIdDocumentResubmissionTemplatePreviewIntegrationTest : IntegrationTest() {
 
     companion object {
-        private const val DOCUMENT_TEMPLATE_ID = "296a8fe6-8767-477b-9173-ea9feb82fbda"
+        private const val DOCUMENT_TEMPLATE_ID = "bd30cf0b-751b-4590-bf7c-b3a6a3b3b87e"
         private const val URI_TEMPLATE = "/templates/id-document-resubmission/preview"
     }
 
@@ -220,7 +220,13 @@ internal class GenerateIdDocumentResubmissionTemplatePreviewIntegrationTest : In
                     "area": "Charles Area",
                     "postcode": "PE3 6SB"
                   }
-                }
+                },
+                "rejectedDocuments": [
+                    {
+                        "documentType": "birth-certificate",
+                        "rejectionReasons": ["unreadable-document"]
+                    }
+                ]
               }
             }
         """.trimIndent()

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/dto/GenerateResubmissionTemplatePreviewDtoBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/dto/GenerateResubmissionTemplatePreviewDtoBuilder.kt
@@ -28,11 +28,13 @@ fun buildGenerateIdDocumentResubmissionTemplatePreviewDto(
     sourceType: SourceType,
     channel: NotificationChannel = NotificationChannel.EMAIL,
     language: LanguageDto = LanguageDto.ENGLISH,
-    personalisation: IdDocumentPersonalisationDto = buildIdDocumentPersonalisationDto()
+    personalisation: IdDocumentPersonalisationDto = buildIdDocumentPersonalisationDto(),
+    notificationType: NotificationType = NotificationType.ID_DOCUMENT_RESUBMISSION
 ): GenerateIdDocumentResubmissionTemplatePreviewDto =
     GenerateIdDocumentResubmissionTemplatePreviewDto(
         channel = channel,
         language = language,
         personalisation = personalisation,
-        sourceType = sourceType
+        sourceType = sourceType,
+        notificationType = notificationType
     )


### PR DESCRIPTION
This PR adds the code to select the correct template ID for document resubmission comms, based on whether there are rejected documents with reasons or not