### PR TITLE
EIP1-4790 - Introduce IdentityDocumentResubmissionDocumentRejectionTextMapper

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/IdentityDocumentResubmissionDocumentRejectionTextMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/IdentityDocumentResubmissionDocumentRejectionTextMapper.kt
@@ -1,0 +1,107 @@
+package uk.gov.dluhc.notificationsapi.mapper
+
+import org.springframework.stereotype.Component
+import uk.gov.dluhc.notificationsapi.dto.LanguageDto
+import uk.gov.dluhc.notificationsapi.messaging.models.DocumentRejectionReason as DocumentRejectionReasonMessaging
+import uk.gov.dluhc.notificationsapi.messaging.models.DocumentType as DocumentTypeMessaging
+import uk.gov.dluhc.notificationsapi.messaging.models.IdDocumentPersonalisation as IdDocumentPersonalisationMessaging
+import uk.gov.dluhc.notificationsapi.models.DocumentRejectionReason as DocumentRejectionReasonApi
+import uk.gov.dluhc.notificationsapi.models.DocumentType as DocumentTypeApi
+import uk.gov.dluhc.notificationsapi.models.IdDocumentPersonalisation as IdDocumentPersonalisationApi
+
+/**
+ * Class to map rejected documents and their reasons into a snippet of markdown that can subsequently be used to pass
+ * into a personalisation field for inclusion in a gov.uk notify template.
+ *
+ * This is necessary because gov.uk notify templating language is not rich enough to be able to perform the logic and mapping
+ * that is required by the business.
+ */
+@Component
+class IdentityDocumentResubmissionDocumentRejectionTextMapper(
+    private val rejectedDocumentReasonMapper: RejectedDocumentReasonMapper,
+) {
+
+    companion object {
+        private val REJECTED_DOCUMENT_MARKDOWN_TEMPLATE = """
+            <document-type>
+
+            <bulleted-list-of-reasons>
+
+            <rejection-reason-notes>
+
+            ----
+            
+        """.trimIndent()
+    }
+
+    fun toDocumentRejectionText(language: LanguageDto, personalisation: IdDocumentPersonalisationApi): String? {
+        return personalisation.rejectedDocuments?.joinToString("\n") { rejectedDocument ->
+            REJECTED_DOCUMENT_MARKDOWN_TEMPLATE
+                .replaceApiDocumentType(rejectedDocument.documentType)
+                .replaceListOfApiReasons(rejectedDocument.rejectionReasons, language)
+                .replaceRejectionReasonNotes(rejectedDocument.rejectionNotes)
+        }?.plus("\n")
+    }
+
+    fun toDocumentRejectionText(language: LanguageDto, personalisation: IdDocumentPersonalisationMessaging): String? {
+        return personalisation.rejectedDocuments?.joinToString("\n") { rejectedDocument ->
+            REJECTED_DOCUMENT_MARKDOWN_TEMPLATE
+                .replaceMessagingDocumentType(rejectedDocument.documentType)
+                .replaceListOfMessagingReasons(rejectedDocument.rejectionReasons, language)
+                .replaceRejectionReasonNotes(rejectedDocument.rejectionNotes)
+        }?.plus("\n")
+    }
+
+    private fun String.replaceApiDocumentType(documentType: DocumentTypeApi): String =
+        replace(
+            "<document-type>",
+            documentType.toString()
+        )
+
+    private fun String.replaceListOfApiReasons(
+        documentRejectionReasons: List<DocumentRejectionReasonApi>,
+        language: LanguageDto,
+    ): String =
+        replace(
+            "<bulleted-list-of-reasons>\n\n",
+            if (documentRejectionReasons.isNotEmpty()) {
+                documentRejectionReasons.joinToString("\n") {
+                    "* ${rejectedDocumentReasonMapper.toDocumentRejectionReasonString(it, language)}"
+                }.plus("\n\n")
+            } else {
+                ""
+            }
+        )
+
+    private fun String.replaceRejectionReasonNotes(rejectionNotes: String?): String =
+        replace(
+            "<rejection-reason-notes>\n\n",
+            if (!rejectionNotes.isNullOrBlank()) {
+                rejectionNotes
+                    .plus("\n\n")
+            } else {
+                ""
+            }
+        )
+
+    private fun String.replaceMessagingDocumentType(documentType: DocumentTypeMessaging): String =
+        replace(
+            "<document-type>",
+            documentType.toString()
+        )
+
+    private fun String.replaceListOfMessagingReasons(
+        documentRejectionReasons: List<DocumentRejectionReasonMessaging>,
+        language: LanguageDto,
+    ): String =
+        replace(
+            "<bulleted-list-of-reasons>\n\n",
+            if (documentRejectionReasons.isNotEmpty()) {
+                documentRejectionReasons.joinToString("\n") {
+                    "* ${rejectedDocumentReasonMapper.toDocumentRejectionReasonString(it, language)}"
+                }.plus("\n\n")
+            } else {
+                ""
+            }
+        )
+}

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/RejectedDocumentReasonMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/RejectedDocumentReasonMapper.kt
@@ -3,13 +3,25 @@ package uk.gov.dluhc.notificationsapi.mapper
 import org.springframework.context.MessageSource
 import org.springframework.stereotype.Component
 import uk.gov.dluhc.notificationsapi.dto.LanguageDto
-import uk.gov.dluhc.notificationsapi.models.DocumentRejectionReason
+import uk.gov.dluhc.notificationsapi.messaging.models.DocumentRejectionReason as DocumentRejectionReasonMessaging
+import uk.gov.dluhc.notificationsapi.models.DocumentRejectionReason as DocumentRejectionReasonApi
 
 @Component
 class RejectedDocumentReasonMapper(private val messageSource: MessageSource) {
 
     fun toDocumentRejectionReasonString(
-        documentRejectionReason: DocumentRejectionReason,
+        documentRejectionReason: DocumentRejectionReasonApi,
+        languageDto: LanguageDto
+    ): String {
+        return messageSource.getMessage(
+            "templates.document-rejection.rejection-reasons.${documentRejectionReason.value}",
+            null,
+            languageDto.locale
+        )
+    }
+
+    fun toDocumentRejectionReasonString(
+        documentRejectionReason: DocumentRejectionReasonMessaging,
         languageDto: LanguageDto
     ): String {
         return messageSource.getMessage(

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/IdentityDocumentResubmissionDocumentRejectionTextMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/IdentityDocumentResubmissionDocumentRejectionTextMapperTest.kt
@@ -1,0 +1,542 @@
+package uk.gov.dluhc.notificationsapi.mapper
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import uk.gov.dluhc.notificationsapi.dto.LanguageDto.ENGLISH
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.messaging.models.buildIdDocumentPersonalisationMessage
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.models.buildIdDocumentPersonalisation
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.models.buildRejectedDocument
+import uk.gov.dluhc.notificationsapi.messaging.models.DocumentRejectionReason as DocumentRejectionReasonMessaging
+import uk.gov.dluhc.notificationsapi.messaging.models.DocumentType as DocumentTypeMessaging
+import uk.gov.dluhc.notificationsapi.models.DocumentRejectionReason as DocumentRejectionReasonApi
+import uk.gov.dluhc.notificationsapi.models.DocumentType as DocumentTypeApi
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.messaging.models.buildRejectedDocument as buildRejectedDocumentMessage
+
+@ExtendWith(MockitoExtension::class)
+class IdentityDocumentResubmissionDocumentRejectionTextMapperTest {
+
+    @InjectMocks
+    private lateinit var rejectionTextMapper: IdentityDocumentResubmissionDocumentRejectionTextMapper
+
+    @Mock
+    private lateinit var rejectedDocumentReasonMapper: RejectedDocumentReasonMapper
+
+    @Nested
+    inner class ToApplicationRejectionReasonStringFromApiEnum {
+        @Test
+        fun `should map to document rejection text given 1 rejected document with 1 reason and no notes`() {
+            // Given
+            val personalisation = buildIdDocumentPersonalisation(
+                rejectedDocuments = listOf(
+                    buildRejectedDocument(
+                        documentType = DocumentTypeApi.BIRTH_MINUS_CERTIFICATE,
+                        rejectionReasons = listOf(DocumentRejectionReasonApi.UNREADABLE_MINUS_DOCUMENT),
+                        rejectionNotes = null
+                    )
+                )
+            )
+
+            given(rejectedDocumentReasonMapper.toDocumentRejectionReasonString(any<DocumentRejectionReasonApi>(), any()))
+                .willReturn("We were unable to read the document provided because it was not clear or not showing the information we needed")
+
+            val expected = """
+                BIRTH_MINUS_CERTIFICATE
+                
+                * We were unable to read the document provided because it was not clear or not showing the information we needed
+                
+                ----
+                
+                
+            """.trimIndent()
+
+            // When
+            val actual = rejectionTextMapper.toDocumentRejectionText(ENGLISH, personalisation)
+
+            // Then
+            assertThat(actual).isEqualTo(expected)
+            verify(rejectedDocumentReasonMapper).toDocumentRejectionReasonString(DocumentRejectionReasonApi.UNREADABLE_MINUS_DOCUMENT, ENGLISH)
+        }
+
+        @Test
+        fun `should map to document rejection text given 1 rejected document with no reasons and some notes`() {
+            // Given
+            val personalisation = buildIdDocumentPersonalisation(
+                rejectedDocuments = listOf(
+                    buildRejectedDocument(
+                        documentType = DocumentTypeApi.BIRTH_MINUS_CERTIFICATE,
+                        rejectionReasons = emptyList(),
+                        rejectionNotes = "This birth certificate is not yours and is someone else's name. You must provide your own documents only."
+                    )
+                )
+            )
+
+            val expected = """
+                BIRTH_MINUS_CERTIFICATE
+                
+                This birth certificate is not yours and is someone else's name. You must provide your own documents only.
+                
+                ----
+                
+                
+            """.trimIndent()
+
+            // When
+            val actual = rejectionTextMapper.toDocumentRejectionText(ENGLISH, personalisation)
+
+            // Then
+            assertThat(actual).isEqualTo(expected)
+            verifyNoInteractions(rejectedDocumentReasonMapper)
+        }
+
+        @Test
+        fun `should map to document rejection text given 1 rejected document with 2 reasons and no notes`() {
+            // Given
+            val personalisation = buildIdDocumentPersonalisation(
+                rejectedDocuments = listOf(
+                    buildRejectedDocument(
+                        documentType = DocumentTypeApi.BIRTH_MINUS_CERTIFICATE,
+                        rejectionReasons = listOf(
+                            DocumentRejectionReasonApi.UNREADABLE_MINUS_DOCUMENT,
+                            DocumentRejectionReasonApi.DUPLICATE_MINUS_DOCUMENT,
+                        ),
+                        rejectionNotes = null
+                    )
+                )
+            )
+
+            given(rejectedDocumentReasonMapper.toDocumentRejectionReasonString(any<DocumentRejectionReasonApi>(), any()))
+                .willReturn(
+                    "We were unable to read the document provided because it was not clear or not showing the information we needed",
+                    "This was a duplicate of another document that you have provided"
+                )
+
+            val expected = """
+                BIRTH_MINUS_CERTIFICATE
+                
+                * We were unable to read the document provided because it was not clear or not showing the information we needed
+                * This was a duplicate of another document that you have provided
+                
+                ----
+                
+                
+            """.trimIndent()
+
+            // When
+            val actual = rejectionTextMapper.toDocumentRejectionText(ENGLISH, personalisation)
+
+            // Then
+            assertThat(actual).isEqualTo(expected)
+            verify(rejectedDocumentReasonMapper).toDocumentRejectionReasonString(DocumentRejectionReasonApi.UNREADABLE_MINUS_DOCUMENT, ENGLISH)
+            verify(rejectedDocumentReasonMapper).toDocumentRejectionReasonString(DocumentRejectionReasonApi.DUPLICATE_MINUS_DOCUMENT, ENGLISH)
+        }
+        @Test
+        fun `should map to document rejection text given 1 rejected document with 2 reasons and some notes`() {
+            // Given
+            val personalisation = buildIdDocumentPersonalisation(
+                rejectedDocuments = listOf(
+                    buildRejectedDocument(
+                        documentType = DocumentTypeApi.BIRTH_MINUS_CERTIFICATE,
+                        rejectionReasons = listOf(
+                            DocumentRejectionReasonApi.UNREADABLE_MINUS_DOCUMENT,
+                            DocumentRejectionReasonApi.DUPLICATE_MINUS_DOCUMENT,
+                        ),
+                        rejectionNotes = "You have already provided your birth certificate as part of this application. Please provide a different form of ID"
+                    )
+                )
+            )
+
+            given(rejectedDocumentReasonMapper.toDocumentRejectionReasonString(any<DocumentRejectionReasonApi>(), any()))
+                .willReturn(
+                    "We were unable to read the document provided because it was not clear or not showing the information we needed",
+                    "This was a duplicate of another document that you have provided"
+                )
+
+            val expected = """
+                BIRTH_MINUS_CERTIFICATE
+                
+                * We were unable to read the document provided because it was not clear or not showing the information we needed
+                * This was a duplicate of another document that you have provided
+                
+                You have already provided your birth certificate as part of this application. Please provide a different form of ID
+                
+                ----
+                
+                
+            """.trimIndent()
+
+            // When
+            val actual = rejectionTextMapper.toDocumentRejectionText(ENGLISH, personalisation)
+
+            // Then
+            assertThat(actual).isEqualTo(expected)
+            verify(rejectedDocumentReasonMapper).toDocumentRejectionReasonString(DocumentRejectionReasonApi.UNREADABLE_MINUS_DOCUMENT, ENGLISH)
+            verify(rejectedDocumentReasonMapper).toDocumentRejectionReasonString(DocumentRejectionReasonApi.DUPLICATE_MINUS_DOCUMENT, ENGLISH)
+        }
+
+        @Test
+        fun `should map to document rejection text given 1 rejected document with no reasons and no notes`() {
+            // Given
+            val personalisation = buildIdDocumentPersonalisation(
+                rejectedDocuments = listOf(
+                    buildRejectedDocument(
+                        documentType = DocumentTypeApi.ADOPTION_MINUS_CERTIFICATE,
+                        rejectionReasons = emptyList(),
+                        rejectionNotes = ""
+                    )
+                )
+            )
+
+            val expected = """
+                ADOPTION_MINUS_CERTIFICATE
+
+                ----
+                
+                
+            """.trimIndent()
+
+            // When
+            val actual = rejectionTextMapper.toDocumentRejectionText(ENGLISH, personalisation)
+
+            // Then
+            assertThat(actual).isEqualTo(expected)
+            verifyNoInteractions(rejectedDocumentReasonMapper)
+        }
+
+        @Test
+        fun `should map to document rejection text given several rejected documents`() {
+            // Given
+            val personalisation = buildIdDocumentPersonalisation(
+                rejectedDocuments = listOf(
+                    buildRejectedDocument(
+                        documentType = DocumentTypeApi.BIRTH_MINUS_CERTIFICATE,
+                        rejectionReasons = listOf(
+                            DocumentRejectionReasonApi.UNREADABLE_MINUS_DOCUMENT,
+                            DocumentRejectionReasonApi.DUPLICATE_MINUS_DOCUMENT,
+                        ),
+                        rejectionNotes = null
+                    ),
+                    buildRejectedDocument(
+                        documentType = DocumentTypeApi.FIREARMS_MINUS_CERTIFICATE,
+                        rejectionReasons = emptyList(),
+                        rejectionNotes = "Your firearms certificate is from your Scouts groups for your air rifle. It is not a formal certificate and is not an acceptable form of ID"
+                    ),
+                    buildRejectedDocument(
+                        documentType = DocumentTypeApi.UTILITY_MINUS_BILL,
+                        rejectionReasons = listOf(DocumentRejectionReasonApi.APPLICANT_MINUS_DETAILS_MINUS_NOT_MINUS_CLEAR),
+                        rejectionNotes = "Your name and address are not clear on the Gas Bill that you provided. Please scan and upload it again ensuring your name and address is clearly visible."
+                    ),
+                    buildRejectedDocument(
+                        documentType = DocumentTypeApi.ADOPTION_MINUS_CERTIFICATE,
+                        rejectionReasons = emptyList(),
+                        rejectionNotes = null
+                    )
+                )
+            )
+
+            given(rejectedDocumentReasonMapper.toDocumentRejectionReasonString(any<DocumentRejectionReasonApi>(), any()))
+                .willReturn(
+                    "We were unable to read the document provided because it was not clear or not showing the information we needed",
+                    "This was a duplicate of another document that you have provided"
+                )
+
+            val expected = """
+                BIRTH_MINUS_CERTIFICATE
+                
+                * We were unable to read the document provided because it was not clear or not showing the information we needed
+                * This was a duplicate of another document that you have provided
+                
+                ----
+                
+                FIREARMS_MINUS_CERTIFICATE
+                
+                Your firearms certificate is from your Scouts groups for your air rifle. It is not a formal certificate and is not an acceptable form of ID
+                
+                ----
+                
+                UTILITY_MINUS_BILL
+                
+                * This was a duplicate of another document that you have provided
+                
+                Your name and address are not clear on the Gas Bill that you provided. Please scan and upload it again ensuring your name and address is clearly visible.
+                
+                ----
+                
+                ADOPTION_MINUS_CERTIFICATE
+
+                ----
+                
+                
+            """.trimIndent()
+
+            // When
+            val actual = rejectionTextMapper.toDocumentRejectionText(ENGLISH, personalisation)
+
+            // Then
+            assertThat(actual).isEqualTo(expected)
+        }
+    }
+
+    @Nested
+    inner class ToApplicationRejectionReasonStringFromMessagingEnum {
+        @Test
+        fun `should map to document rejection text given 1 rejected document with 1 reason and no notes`() {
+            // Given
+            val personalisation = buildIdDocumentPersonalisationMessage(
+                rejectedDocuments = listOf(
+                    buildRejectedDocumentMessage(
+                        documentType = DocumentTypeMessaging.BIRTH_MINUS_CERTIFICATE,
+                        rejectionReasons = listOf(DocumentRejectionReasonMessaging.UNREADABLE_MINUS_DOCUMENT),
+                        rejectionNotes = null
+                    )
+                )
+            )
+
+            given(rejectedDocumentReasonMapper.toDocumentRejectionReasonString(any<DocumentRejectionReasonMessaging>(), any()))
+                .willReturn("We were unable to read the document provided because it was not clear or not showing the information we needed")
+
+            val expected = """
+                BIRTH_MINUS_CERTIFICATE
+                
+                * We were unable to read the document provided because it was not clear or not showing the information we needed
+                
+                ----
+                
+                
+            """.trimIndent()
+
+            // When
+            val actual = rejectionTextMapper.toDocumentRejectionText(ENGLISH, personalisation)
+
+            // Then
+            assertThat(actual).isEqualTo(expected)
+            verify(rejectedDocumentReasonMapper).toDocumentRejectionReasonString(DocumentRejectionReasonMessaging.UNREADABLE_MINUS_DOCUMENT, ENGLISH)
+        }
+
+        @Test
+        fun `should map to document rejection text given 1 rejected document with no reasons and some notes`() {
+            // Given
+            val personalisation = buildIdDocumentPersonalisationMessage(
+                rejectedDocuments = listOf(
+                    buildRejectedDocumentMessage(
+                        documentType = DocumentTypeMessaging.BIRTH_MINUS_CERTIFICATE,
+                        rejectionReasons = emptyList(),
+                        rejectionNotes = "This birth certificate is not yours and is someone else's name. You must provide your own documents only."
+                    )
+                )
+            )
+
+            val expected = """
+                BIRTH_MINUS_CERTIFICATE
+                
+                This birth certificate is not yours and is someone else's name. You must provide your own documents only.
+                
+                ----
+                
+                
+            """.trimIndent()
+
+            // When
+            val actual = rejectionTextMapper.toDocumentRejectionText(ENGLISH, personalisation)
+
+            // Then
+            assertThat(actual).isEqualTo(expected)
+            verifyNoInteractions(rejectedDocumentReasonMapper)
+        }
+
+        @Test
+        fun `should map to document rejection text given 1 rejected document with 2 reasons and no notes`() {
+            // Given
+            val personalisation = buildIdDocumentPersonalisationMessage(
+                rejectedDocuments = listOf(
+                    buildRejectedDocumentMessage(
+                        documentType = DocumentTypeMessaging.BIRTH_MINUS_CERTIFICATE,
+                        rejectionReasons = listOf(
+                            DocumentRejectionReasonMessaging.UNREADABLE_MINUS_DOCUMENT,
+                            DocumentRejectionReasonMessaging.DUPLICATE_MINUS_DOCUMENT,
+                        ),
+                        rejectionNotes = null
+                    )
+                )
+            )
+
+            given(rejectedDocumentReasonMapper.toDocumentRejectionReasonString(any<DocumentRejectionReasonMessaging>(), any()))
+                .willReturn(
+                    "We were unable to read the document provided because it was not clear or not showing the information we needed",
+                    "This was a duplicate of another document that you have provided"
+                )
+
+            val expected = """
+                BIRTH_MINUS_CERTIFICATE
+                
+                * We were unable to read the document provided because it was not clear or not showing the information we needed
+                * This was a duplicate of another document that you have provided
+                
+                ----
+                
+                
+            """.trimIndent()
+
+            // When
+            val actual = rejectionTextMapper.toDocumentRejectionText(ENGLISH, personalisation)
+
+            // Then
+            assertThat(actual).isEqualTo(expected)
+            verify(rejectedDocumentReasonMapper).toDocumentRejectionReasonString(DocumentRejectionReasonMessaging.UNREADABLE_MINUS_DOCUMENT, ENGLISH)
+            verify(rejectedDocumentReasonMapper).toDocumentRejectionReasonString(DocumentRejectionReasonMessaging.DUPLICATE_MINUS_DOCUMENT, ENGLISH)
+        }
+        @Test
+        fun `should map to document rejection text given 1 rejected document with 2 reasons and some notes`() {
+            // Given
+            val personalisation = buildIdDocumentPersonalisationMessage(
+                rejectedDocuments = listOf(
+                    buildRejectedDocumentMessage(
+                        documentType = DocumentTypeMessaging.BIRTH_MINUS_CERTIFICATE,
+                        rejectionReasons = listOf(
+                            DocumentRejectionReasonMessaging.UNREADABLE_MINUS_DOCUMENT,
+                            DocumentRejectionReasonMessaging.DUPLICATE_MINUS_DOCUMENT,
+                        ),
+                        rejectionNotes = "You have already provided your birth certificate as part of this application. Please provide a different form of ID"
+                    )
+                )
+            )
+
+            given(rejectedDocumentReasonMapper.toDocumentRejectionReasonString(any<DocumentRejectionReasonMessaging>(), any()))
+                .willReturn(
+                    "We were unable to read the document provided because it was not clear or not showing the information we needed",
+                    "This was a duplicate of another document that you have provided"
+                )
+
+            val expected = """
+                BIRTH_MINUS_CERTIFICATE
+                
+                * We were unable to read the document provided because it was not clear or not showing the information we needed
+                * This was a duplicate of another document that you have provided
+                
+                You have already provided your birth certificate as part of this application. Please provide a different form of ID
+                
+                ----
+                
+                
+            """.trimIndent()
+
+            // When
+            val actual = rejectionTextMapper.toDocumentRejectionText(ENGLISH, personalisation)
+
+            // Then
+            assertThat(actual).isEqualTo(expected)
+            verify(rejectedDocumentReasonMapper).toDocumentRejectionReasonString(DocumentRejectionReasonMessaging.UNREADABLE_MINUS_DOCUMENT, ENGLISH)
+            verify(rejectedDocumentReasonMapper).toDocumentRejectionReasonString(DocumentRejectionReasonMessaging.DUPLICATE_MINUS_DOCUMENT, ENGLISH)
+        }
+
+        @Test
+        fun `should map to document rejection text given 1 rejected document with no reasons and no notes`() {
+            // Given
+            val personalisation = buildIdDocumentPersonalisationMessage(
+                rejectedDocuments = listOf(
+                    buildRejectedDocumentMessage(
+                        documentType = DocumentTypeMessaging.ADOPTION_MINUS_CERTIFICATE,
+                        rejectionReasons = emptyList(),
+                        rejectionNotes = ""
+                    )
+                )
+            )
+
+            val expected = """
+                ADOPTION_MINUS_CERTIFICATE
+
+                ----
+                
+                
+            """.trimIndent()
+
+            // When
+            val actual = rejectionTextMapper.toDocumentRejectionText(ENGLISH, personalisation)
+
+            // Then
+            assertThat(actual).isEqualTo(expected)
+            verifyNoInteractions(rejectedDocumentReasonMapper)
+        }
+
+        @Test
+        fun `should map to document rejection text given several rejected documents`() {
+            // Given
+            val personalisation = buildIdDocumentPersonalisationMessage(
+                rejectedDocuments = listOf(
+                    buildRejectedDocumentMessage(
+                        documentType = DocumentTypeMessaging.BIRTH_MINUS_CERTIFICATE,
+                        rejectionReasons = listOf(
+                            DocumentRejectionReasonMessaging.UNREADABLE_MINUS_DOCUMENT,
+                            DocumentRejectionReasonMessaging.DUPLICATE_MINUS_DOCUMENT,
+                        ),
+                        rejectionNotes = null
+                    ),
+                    buildRejectedDocumentMessage(
+                        documentType = DocumentTypeMessaging.FIREARMS_MINUS_CERTIFICATE,
+                        rejectionReasons = emptyList(),
+                        rejectionNotes = "Your firearms certificate is from your Scouts groups for your air rifle. It is not a formal certificate and is not an acceptable form of ID"
+                    ),
+                    buildRejectedDocumentMessage(
+                        documentType = DocumentTypeMessaging.UTILITY_MINUS_BILL,
+                        rejectionReasons = listOf(DocumentRejectionReasonMessaging.APPLICANT_MINUS_DETAILS_MINUS_NOT_MINUS_CLEAR),
+                        rejectionNotes = "Your name and address are not clear on the Gas Bill that you provided. Please scan and upload it again ensuring your name and address is clearly visible."
+                    ),
+                    buildRejectedDocumentMessage(
+                        documentType = DocumentTypeMessaging.ADOPTION_MINUS_CERTIFICATE,
+                        rejectionReasons = emptyList(),
+                        rejectionNotes = null
+                    )
+                )
+            )
+
+            given(rejectedDocumentReasonMapper.toDocumentRejectionReasonString(any<DocumentRejectionReasonMessaging>(), any()))
+                .willReturn(
+                    "We were unable to read the document provided because it was not clear or not showing the information we needed",
+                    "This was a duplicate of another document that you have provided"
+                )
+
+            val expected = """
+                BIRTH_MINUS_CERTIFICATE
+                
+                * We were unable to read the document provided because it was not clear or not showing the information we needed
+                * This was a duplicate of another document that you have provided
+                
+                ----
+                
+                FIREARMS_MINUS_CERTIFICATE
+                
+                Your firearms certificate is from your Scouts groups for your air rifle. It is not a formal certificate and is not an acceptable form of ID
+                
+                ----
+                
+                UTILITY_MINUS_BILL
+                
+                * This was a duplicate of another document that you have provided
+                
+                Your name and address are not clear on the Gas Bill that you provided. Please scan and upload it again ensuring your name and address is clearly visible.
+                
+                ----
+                
+                ADOPTION_MINUS_CERTIFICATE
+
+                ----
+                
+                
+            """.trimIndent()
+
+            // When
+            val actual = rejectionTextMapper.toDocumentRejectionText(ENGLISH, personalisation)
+
+            // Then
+            assertThat(actual).isEqualTo(expected)
+        }
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/RejectedDocumentReasonMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/RejectedDocumentReasonMapperTest.kt
@@ -6,7 +6,8 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.springframework.context.support.ResourceBundleMessageSource
 import uk.gov.dluhc.notificationsapi.dto.LanguageDto
-import uk.gov.dluhc.notificationsapi.models.DocumentRejectionReason
+import uk.gov.dluhc.notificationsapi.messaging.models.DocumentRejectionReason as DocumentRejectionReasonMessaging
+import uk.gov.dluhc.notificationsapi.models.DocumentRejectionReason as DocumentRejectionReasonApi
 
 class RejectedDocumentReasonMapperTest {
 
@@ -32,7 +33,7 @@ class RejectedDocumentReasonMapperTest {
             ]
         )
         fun `should map enums to human readable messages in English`(
-            rejectionReason: DocumentRejectionReason,
+            rejectionReason: DocumentRejectionReasonApi,
             expected: String
         ) {
             // Given
@@ -58,7 +59,60 @@ class RejectedDocumentReasonMapperTest {
         ]
     )
     fun `should map enums to human readable messages in Welsh`(
-        rejectionReason: DocumentRejectionReason,
+        rejectionReason: DocumentRejectionReasonApi,
+        expected: String
+    ) {
+        // Given
+
+        // When
+        val actual = mapper.toDocumentRejectionReasonString(rejectionReason, LanguageDto.WELSH)
+
+        // Then
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Nested
+    inner class ToDocumentRejectionReasonStringFromMessagingEnum {
+        @ParameterizedTest
+        @CsvSource(
+            value = [
+                "DOCUMENT_MINUS_TOO_MINUS_OLD, The document is too old",
+                "UNREADABLE_MINUS_DOCUMENT, We were unable to read the document provided because it was not clear or not showing the information we needed",
+                "INVALID_MINUS_DOCUMENT_MINUS_TYPE, The document provided is not of a type that we can accept for the purposes of checking your identity",
+                "DUPLICATE_MINUS_DOCUMENT, This was a duplicate of another document that you have provided",
+                "INVALID_MINUS_DOCUMENT_MINUS_COUNTRY, We are not able to accept documents from this country for the purposes of checking your identity",
+                "APPLICANT_MINUS_DETAILS_MINUS_NOT_MINUS_CLEAR, The document needs to clearly show your name",
+                "DETAILS_MINUS_ON_MINUS_DOCUMENT_MINUS_DO_MINUS_NOT_MINUS_MATCH, Information provided on the document does not match information from your application"
+            ]
+        )
+        fun `should map enums to human readable messages in English`(
+            rejectionReason: DocumentRejectionReasonMessaging,
+            expected: String
+        ) {
+            // Given
+
+            // When
+            val actual = mapper.toDocumentRejectionReasonString(rejectionReason, LanguageDto.ENGLISH)
+
+            // Then
+            assertThat(actual).isEqualTo(expected)
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            "DOCUMENT_MINUS_TOO_MINUS_OLD, Mae'r ddogfen yn rhy hen",
+            "UNREADABLE_MINUS_DOCUMENT, Nid oeddem yn gallu darllen y ddogfen a ddarparwyd oherwydd nad oedd yn glir neu oherwydd nad oedd yn dangos y wybodaeth yr oedd ei hangen arnom",
+            "INVALID_MINUS_DOCUMENT_MINUS_TYPE, Nid yw'r ddogfen a ddarparwyd o fath y gallwn ei derbyn at ddibenion gwirio pwy ydych",
+            "DUPLICATE_MINUS_DOCUMENT, Roedd hwn yn gopi dyblyg o ddogfen arall a ddarparwyd gennych",
+            "INVALID_MINUS_DOCUMENT_MINUS_COUNTRY, Ni allwn dderbyn dogfennau o'r wlad hon at ddibenion gwirio pwy ydych",
+            "APPLICANT_MINUS_DETAILS_MINUS_NOT_MINUS_CLEAR, Mae angen i'r ddogfen ddangos eich enw'n glir",
+            "DETAILS_MINUS_ON_MINUS_DOCUMENT_MINUS_DO_MINUS_NOT_MINUS_MATCH, Nid yw'r wybodaeth a ddarperir ar y ddogfen yn cyfateb i'r wybodaeth o'ch cais"
+        ]
+    )
+    fun `should map enums to human readable messages in Welsh`(
+        rejectionReason: DocumentRejectionReasonMessaging,
         expected: String
     ) {
         // Given

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/models/NotificationsIdDocumentPersonalisationBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/models/NotificationsIdDocumentPersonalisationBuilder.kt
@@ -1,0 +1,21 @@
+package uk.gov.dluhc.notificationsapi.testsupport.testdata.models
+
+import uk.gov.dluhc.notificationsapi.models.ContactDetails
+import uk.gov.dluhc.notificationsapi.models.IdDocumentPersonalisation
+import uk.gov.dluhc.notificationsapi.models.RejectedDocument
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.DataFaker.Companion.faker
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.aValidApplicationReference
+
+fun buildIdDocumentPersonalisation(
+    applicationReference: String = aValidApplicationReference(),
+    firstName: String = faker.name().firstName(),
+    eroContactDetails: ContactDetails = buildEroContactDetails(),
+    idDocumentRequestFreeText: String = faker.harryPotter().spell(),
+    rejectedDocuments: List<RejectedDocument>? = listOf(buildRejectedDocument())
+) = IdDocumentPersonalisation(
+    applicationReference = applicationReference,
+    firstName = firstName,
+    eroContactDetails = eroContactDetails,
+    idDocumentRequestFreeText = idDocumentRequestFreeText,
+    rejectedDocuments = rejectedDocuments
+)


### PR DESCRIPTION
This PR adds a mapper class which is responsible for mapping document rejection reasons (both REST API and Messaging API) into a block of markdown, which will then (future PR) be used to pass into the gov.uk notify templates 
We have to do this because gov.uk notify templating is not rich enough to loop and render text in the way we need to.