### PR TITLE
EIP1-4790 - Any rejected doc with reasons or notes now uses new template

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/IdentityDocumentResubmissionTemplatePreviewDtoMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/IdentityDocumentResubmissionTemplatePreviewDtoMapper.kt
@@ -28,11 +28,11 @@ abstract class IdentityDocumentResubmissionTemplatePreviewDtoMapper {
     ): GenerateIdDocumentResubmissionTemplatePreviewDto
 
     protected fun idDocumentResubmissionNotificationType(request: GenerateIdDocumentResubmissionTemplatePreviewRequest): NotificationType =
-        // ID_DOCUMENT_RESUBMISSION_WITH_REASONS should be used if all rejected documents have either any rejection reasons (excluding OTHER)
+        // ID_DOCUMENT_RESUBMISSION_WITH_REASONS should be used if any rejected documents have either any rejection reasons (excluding OTHER)
         // or has rejection notes
         with(request.personalisation) {
             if (!rejectedDocuments.isNullOrEmpty() &&
-                rejectedDocuments.all { it.rejectionReasonsExcludingOther.isNotEmpty() || !it.rejectionNotes.isNullOrBlank() }
+                rejectedDocuments.any { it.rejectionReasonsExcludingOther.isNotEmpty() || !it.rejectionNotes.isNullOrBlank() }
             )
                 ID_DOCUMENT_RESUBMISSION_WITH_REASONS
             else

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/SendNotifyMessageMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/SendNotifyMessageMapper.kt
@@ -73,11 +73,11 @@ abstract class SendNotifyMessageMapper {
         }
 
     protected fun idDocumentResubmissionNotificationType(message: SendNotifyIdDocumentResubmissionMessage): NotificationType =
-        // ID_DOCUMENT_RESUBMISSION_WITH_REASONS should be used if all rejected documents have either any rejection reasons (excluding OTHER)
+        // ID_DOCUMENT_RESUBMISSION_WITH_REASONS should be used if any rejected documents have either any rejection reasons (excluding OTHER)
         // or has rejection notes
         with(message.personalisation) {
             if (rejectedDocuments.isNotEmpty() &&
-                rejectedDocuments.all { it.rejectionReasonsExcludingOther.isNotEmpty() || !it.rejectionNotes.isNullOrBlank() }
+                rejectedDocuments.any { it.rejectionReasonsExcludingOther.isNotEmpty() || !it.rejectionNotes.isNullOrBlank() }
             )
                 ID_DOCUMENT_RESUBMISSION_WITH_REASONS
             else

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/IdentityDocumentResubmissionTemplatePreviewDtoMapper_NotificationTypeTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/IdentityDocumentResubmissionTemplatePreviewDtoMapper_NotificationTypeTest.kt
@@ -246,6 +246,42 @@ class IdentityDocumentResubmissionTemplatePreviewDtoMapper_NotificationTypeTest 
         val actual = mapper.toIdDocumentResubmissionTemplatePreviewDto(request)
 
         // Then
+        assertThat(actual.notificationType).isEqualTo(ID_DOCUMENT_RESUBMISSION_WITH_REASONS)
+    }
+
+    @Test
+    fun `should map ID document template request to dto with correct NotificationType mapping given no documents have rejection reasons or rejection notes`() {
+        // Given
+        val request = buildGenerateIdDocumentResubmissionTemplatePreviewRequest(
+            channel = NotificationChannel.LETTER,
+            language = Language.EN,
+            sourceType = SourceType.VOTER_MINUS_CARD,
+            personalisation = buildIdDocumentResubmissionPersonalisationRequest(
+                rejectedDocuments = listOf(
+                    buildRejectedDocument(
+                        rejectionReasons = emptyList(),
+                        rejectionNotes = null
+                    ),
+                    buildRejectedDocument(
+                        rejectionReasons = emptyList(),
+                        rejectionNotes = null
+                    ),
+                    buildRejectedDocument(
+                        rejectionReasons = emptyList(),
+                        rejectionNotes = null
+                    )
+                )
+            )
+        )
+
+        given(languageMapper.fromApiToDto(any())).willReturn(LanguageDto.ENGLISH)
+        given(channelMapper.fromApiToDto(any())).willReturn(uk.gov.dluhc.notificationsapi.dto.NotificationChannel.LETTER)
+        given(sourceTypeMapper.fromApiToDto(any())).willReturn(uk.gov.dluhc.notificationsapi.dto.SourceType.VOTER_CARD)
+
+        // When
+        val actual = mapper.toIdDocumentResubmissionTemplatePreviewDto(request)
+
+        // Then
         assertThat(actual.notificationType).isEqualTo(ID_DOCUMENT_RESUBMISSION)
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/SendNotifyMessageMapper_NotificationTypeTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/SendNotifyMessageMapper_NotificationTypeTest.kt
@@ -427,6 +427,41 @@ internal class SendNotifyMessageMapper_NotificationTypeTest {
             val actual = mapper.fromIdDocumentMessageToSendNotificationRequestDto(request)
 
             // Then
+            assertThat(actual.notificationType).isEqualTo(ID_DOCUMENT_RESUBMISSION_WITH_REASONS)
+        }
+
+        @Test
+        fun `should map ID document template request to dto with correct NotificationType mapping given no documents have rejection reasons or rejection notes`() {
+            // Given
+            val request = buildSendNotifyIdDocumentResubmissionMessage(
+                personalisation = buildIdDocumentPersonalisationMessage(
+                    rejectedDocuments = listOf(
+                        buildRejectedDocument(
+                            rejectionReasons = emptyList(),
+                            rejectionNotes = null
+                        ),
+                        buildRejectedDocument(
+                            rejectionReasons = emptyList(),
+                            rejectionNotes = null
+                        ),
+                        buildRejectedDocument(
+                            rejectionReasons = emptyList(),
+                            rejectionNotes = null
+                        )
+                    )
+                )
+            )
+
+            given(languageMapper.fromMessageToDto(any())).willReturn(ENGLISH)
+            given(sourceTypeMapper.fromMessageToDto(any())).willReturn(aSourceType())
+            given(notificationDestinationDtoMapper.toNotificationDestinationDto(any()))
+                .willReturn(aNotificationDestination())
+            given(notificationChannelMapper.fromMessagingApiToDto(any())).willReturn(aNotificationChannel())
+
+            // When
+            val actual = mapper.fromIdDocumentMessageToSendNotificationRequestDto(request)
+
+            // Then
             assertThat(actual.notificationType).isEqualTo(ID_DOCUMENT_RESUBMISSION)
         }
     }


### PR DESCRIPTION
This PR changes the logic re: whether the gov.uk template `ID_DOCUMENT_RESUBMISSION` (the original template) or `ID_DOCUMENT_RESUBMISSION_WITH_REASONS` (new template) is used

Previously **all** rejected documents had to have either one or more rejection reasons, or rejection notes

This logic has been changed (by request and agreement from the business / Ian) so that is is now **any** rejected documents having either one or more rejection reasons, or rejection notes