### PR TITLE
EIP1-4790 - Wired in IdentityDocumentResubmissionDocumentRejectionTextMapper

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/dto/TemplatePersonalisationDto.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/dto/TemplatePersonalisationDto.kt
@@ -10,7 +10,8 @@ class IdDocumentPersonalisationDto(
     applicationReference: String,
     firstName: String,
     eroContactDetails: ContactDetailsDto,
-    val idDocumentRequestFreeText: String
+    val idDocumentRequestFreeText: String,
+    val documentRejectionText: String?
 ) : BaseTemplatePersonalisationDto(
     applicationReference = applicationReference,
     firstName = firstName,

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/IdentityDocumentResubmissionTemplatePreviewDtoMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/IdentityDocumentResubmissionTemplatePreviewDtoMapper.kt
@@ -1,18 +1,28 @@
 package uk.gov.dluhc.notificationsapi.mapper
 
-import org.apache.commons.lang3.StringUtils.isNotBlank
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping
+import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.dluhc.notificationsapi.dto.GenerateIdDocumentResubmissionTemplatePreviewDto
+import uk.gov.dluhc.notificationsapi.dto.IdDocumentPersonalisationDto
+import uk.gov.dluhc.notificationsapi.dto.LanguageDto
 import uk.gov.dluhc.notificationsapi.dto.NotificationType
 import uk.gov.dluhc.notificationsapi.dto.NotificationType.ID_DOCUMENT_RESUBMISSION
 import uk.gov.dluhc.notificationsapi.dto.NotificationType.ID_DOCUMENT_RESUBMISSION_WITH_REASONS
 import uk.gov.dluhc.notificationsapi.models.GenerateIdDocumentResubmissionTemplatePreviewRequest
+import uk.gov.dluhc.notificationsapi.models.IdDocumentPersonalisation
 
 @Mapper(uses = [LanguageMapper::class, NotificationChannelMapper::class, SourceTypeMapper::class])
 abstract class IdentityDocumentResubmissionTemplatePreviewDtoMapper {
 
+    @Autowired
+    protected lateinit var documentRejectionTextMapper: IdentityDocumentResubmissionDocumentRejectionTextMapper
+
     @Mapping(target = "notificationType", expression = "java( idDocumentResubmissionNotificationType(request) )")
+    @Mapping(
+        target = "personalisation",
+        expression = "java( mapPersonalisation( language, request.getPersonalisation() ) )"
+    )
     abstract fun toIdDocumentResubmissionTemplatePreviewDto(
         request: GenerateIdDocumentResubmissionTemplatePreviewRequest,
     ): GenerateIdDocumentResubmissionTemplatePreviewDto
@@ -22,10 +32,19 @@ abstract class IdentityDocumentResubmissionTemplatePreviewDtoMapper {
         // or has rejection notes
         with(request.personalisation) {
             if (!rejectedDocuments.isNullOrEmpty() &&
-                rejectedDocuments.all { it.rejectionReasonsExcludingOther.isNotEmpty() || isNotBlank(it.rejectionNotes) }
+                rejectedDocuments.all { it.rejectionReasonsExcludingOther.isNotEmpty() || !it.rejectionNotes.isNullOrBlank() }
             )
                 ID_DOCUMENT_RESUBMISSION_WITH_REASONS
             else
                 ID_DOCUMENT_RESUBMISSION
         }
+
+    @Mapping(
+        target = "documentRejectionText",
+        expression = "java( documentRejectionTextMapper.toDocumentRejectionText( languageDto, personalisation ) )"
+    )
+    protected abstract fun mapPersonalisation(
+        languageDto: LanguageDto,
+        personalisation: IdDocumentPersonalisation
+    ): IdDocumentPersonalisationDto
 }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/PhotoResubmissionTemplatePreviewDtoMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/PhotoResubmissionTemplatePreviewDtoMapper.kt
@@ -1,6 +1,5 @@
 package uk.gov.dluhc.notificationsapi.mapper
 
-import org.apache.commons.lang3.StringUtils.isNotBlank
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping
 import org.springframework.beans.factory.annotation.Autowired
@@ -31,7 +30,7 @@ abstract class PhotoResubmissionTemplatePreviewDtoMapper {
     protected fun photoResubmissionNotificationType(request: GeneratePhotoResubmissionTemplatePreviewRequest): NotificationType =
         // PHOTO_RESUBMISSION_WITH_REASONS should be used if there are rejection reasons (excluding OTHER) or there are rejection notes
         with(request.personalisation) {
-            if (photoRejectionReasonsExcludingOther.isNotEmpty() || isNotBlank(photoRejectionNotes))
+            if (photoRejectionReasonsExcludingOther.isNotEmpty() || !photoRejectionNotes.isNullOrBlank())
                 PHOTO_RESUBMISSION_WITH_REASONS
             else
                 PHOTO_RESUBMISSION

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/TemplatePersonalisationDtoMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/TemplatePersonalisationDtoMapper.kt
@@ -34,6 +34,9 @@ class TemplatePersonalisationDtoMapper {
 
         with(dto) {
             personalisation["documentRequestFreeText"] = idDocumentRequestFreeText
+            if (!documentRejectionText.isNullOrEmpty()) {
+                personalisation["documentRejectionText"] = documentRejectionText
+            }
         }
         return personalisation
     }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyIdDocumentResubmissionMessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyIdDocumentResubmissionMessageListener.kt
@@ -32,7 +32,7 @@ class SendNotifyIdDocumentResubmissionMessageListener(
         }
         with(payload) {
             val sendNotificationRequestDto = sendNotifyMessageMapper.fromIdDocumentMessageToSendNotificationRequestDto(this)
-            val personalisationDto = templatePersonalisationMessageMapper.toIdDocumentPersonalisationDto(personalisation)
+            val personalisationDto = templatePersonalisationMessageMapper.toIdDocumentPersonalisationDto(personalisation, sendNotificationRequestDto.language)
             val personalisationMap = templatePersonalisationDtoMapper.toIdDocumentResubmissionTemplatePersonalisationMap(personalisationDto)
             sendNotificationService.sendNotification(sendNotificationRequestDto, personalisationMap)
         }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/SendNotifyMessageMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/SendNotifyMessageMapper.kt
@@ -1,6 +1,5 @@
 package uk.gov.dluhc.notificationsapi.messaging.mapper
 
-import org.apache.commons.lang3.StringUtils.isNotBlank
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping
 import uk.gov.dluhc.notificationsapi.dto.NotificationType
@@ -67,7 +66,7 @@ abstract class SendNotifyMessageMapper {
     protected fun photoResubmissionNotificationType(message: SendNotifyPhotoResubmissionMessage): NotificationType =
         // PHOTO_RESUBMISSION_WITH_REASONS should be used if there are rejection reasons (excluding OTHER) or there are rejection notes
         with(message.personalisation) {
-            if (photoRejectionReasonsExcludingOther.isNotEmpty() || isNotBlank(photoRejectionNotes))
+            if (photoRejectionReasonsExcludingOther.isNotEmpty() || !photoRejectionNotes.isNullOrBlank())
                 PHOTO_RESUBMISSION_WITH_REASONS
             else
                 PHOTO_RESUBMISSION
@@ -78,7 +77,7 @@ abstract class SendNotifyMessageMapper {
         // or has rejection notes
         with(message.personalisation) {
             if (rejectedDocuments.isNotEmpty() &&
-                rejectedDocuments.all { it.rejectionReasonsExcludingOther.isNotEmpty() || isNotBlank(it.rejectionNotes) }
+                rejectedDocuments.all { it.rejectionReasonsExcludingOther.isNotEmpty() || !it.rejectionNotes.isNullOrBlank() }
             )
                 ID_DOCUMENT_RESUBMISSION_WITH_REASONS
             else

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/TemplatePersonalisationMessageMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/TemplatePersonalisationMessageMapper.kt
@@ -11,6 +11,7 @@ import uk.gov.dluhc.notificationsapi.dto.IdDocumentRequiredPersonalisationDto
 import uk.gov.dluhc.notificationsapi.dto.LanguageDto
 import uk.gov.dluhc.notificationsapi.dto.PhotoPersonalisationDto
 import uk.gov.dluhc.notificationsapi.mapper.ApplicationRejectionReasonMapper
+import uk.gov.dluhc.notificationsapi.mapper.IdentityDocumentResubmissionDocumentRejectionTextMapper
 import uk.gov.dluhc.notificationsapi.mapper.PhotoRejectionReasonMapper
 import uk.gov.dluhc.notificationsapi.messaging.models.ApplicationRejectedPersonalisation
 import uk.gov.dluhc.notificationsapi.messaging.models.BasePersonalisation
@@ -27,6 +28,9 @@ abstract class TemplatePersonalisationMessageMapper {
     @Autowired
     protected lateinit var photoRejectionReasonMapper: PhotoRejectionReasonMapper
 
+    @Autowired
+    protected lateinit var documentRejectionTextMapper: IdentityDocumentResubmissionDocumentRejectionTextMapper
+
     @Mapping(
         target = "photoRejectionReasons",
         expression = "java( mapPhotoRejectionReasons( languageDto, personalisationMessage ) )"
@@ -36,7 +40,11 @@ abstract class TemplatePersonalisationMessageMapper {
         languageDto: LanguageDto
     ): PhotoPersonalisationDto
 
-    abstract fun toIdDocumentPersonalisationDto(personalisationMessage: IdDocumentPersonalisation): IdDocumentPersonalisationDto
+    @Mapping(
+        target = "documentRejectionText",
+        expression = "java( mapDocumentRejectionText( languageDto, personalisationMessage ) )"
+    )
+    abstract fun toIdDocumentPersonalisationDto(personalisationMessage: IdDocumentPersonalisation, languageDto: LanguageDto): IdDocumentPersonalisationDto
 
     abstract fun toIdDocumentRequiredPersonalisationDto(personalisationMessage: IdDocumentRequiredPersonalisation): IdDocumentRequiredPersonalisationDto
 
@@ -75,5 +83,12 @@ abstract class TemplatePersonalisationMessageMapper {
                 languageDto
             )
         }
+    }
+
+    protected fun mapDocumentRejectionText(
+        languageDto: LanguageDto,
+        personalisation: IdDocumentPersonalisation
+    ): String? {
+        return documentRejectionTextMapper.toDocumentRejectionText(languageDto, personalisation)
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/IdentityDocumentResubmissionTemplatePreviewDtoMapper_NotificationTypeTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/IdentityDocumentResubmissionTemplatePreviewDtoMapper_NotificationTypeTest.kt
@@ -47,6 +47,9 @@ class IdentityDocumentResubmissionTemplatePreviewDtoMapper_NotificationTypeTest 
     @Mock
     private lateinit var sourceTypeMapper: SourceTypeMapper
 
+    @Mock
+    private lateinit var documentRejectionTextMapper: IdentityDocumentResubmissionDocumentRejectionTextMapper
+
     companion object {
         @JvmStatic
         fun documentRejectionReasons_to_NotificationType(): Stream<Arguments> {

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyIdDocumentResubmissionMessageListenerTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyIdDocumentResubmissionMessageListenerTest.kt
@@ -44,7 +44,7 @@ internal class SendNotifyIdDocumentResubmissionMessageListenerTest {
         val personalisationDto = buildIdDocumentPersonalisationDto()
 
         given(sendNotifyMessageMapper.fromIdDocumentMessageToSendNotificationRequestDto(any())).willReturn(requestDto)
-        given(templatePersonalisationMessageMapper.toIdDocumentPersonalisationDto(any())).willReturn(personalisationDto)
+        given(templatePersonalisationMessageMapper.toIdDocumentPersonalisationDto(any(), any())).willReturn(personalisationDto)
         given(templatePersonalisationDtoMapper.toIdDocumentResubmissionTemplatePersonalisationMap(any())).willReturn(personalisationMap)
 
         // When
@@ -52,7 +52,7 @@ internal class SendNotifyIdDocumentResubmissionMessageListenerTest {
 
         // Then
         verify(sendNotifyMessageMapper).fromIdDocumentMessageToSendNotificationRequestDto(sqsMessage)
-        verify(templatePersonalisationMessageMapper).toIdDocumentPersonalisationDto(sqsMessage.personalisation)
+        verify(templatePersonalisationMessageMapper).toIdDocumentPersonalisationDto(sqsMessage.personalisation, requestDto.language)
         verify(templatePersonalisationDtoMapper).toIdDocumentResubmissionTemplatePersonalisationMap(personalisationDto)
         verify(sendNotificationService).sendNotification(requestDto, personalisationMap)
     }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GenerateIdDocumentResubmissionTemplatePreviewIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GenerateIdDocumentResubmissionTemplatePreviewIntegrationTest.kt
@@ -7,6 +7,8 @@ import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.test.web.reactive.server.WebTestClient
 import reactor.core.publisher.Mono
 import uk.gov.dluhc.notificationsapi.config.IntegrationTest
+import uk.gov.dluhc.notificationsapi.models.DocumentRejectionReason
+import uk.gov.dluhc.notificationsapi.models.DocumentType
 import uk.gov.dluhc.notificationsapi.models.ErrorResponse
 import uk.gov.dluhc.notificationsapi.models.GenerateIdDocumentResubmissionTemplatePreviewRequest
 import uk.gov.dluhc.notificationsapi.models.GenerateTemplatePreviewResponse
@@ -19,6 +21,7 @@ import uk.gov.dluhc.notificationsapi.testsupport.testdata.api.buildContactDetail
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.api.buildGenerateIdDocumentResubmissionTemplatePreviewRequest
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.api.buildIdDocumentResubmissionPersonalisationRequest
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.getBearerToken
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.models.buildRejectedDocument
 import java.time.OffsetDateTime
 import java.time.temporal.ChronoUnit.MILLIS
 import uk.gov.dluhc.notificationsapi.models.SourceType as SourceTypeModel
@@ -235,6 +238,7 @@ internal class GenerateIdDocumentResubmissionTemplatePreviewIntegrationTest : In
             "applicationReference" to "A3JSZC4CRH",
             "firstName" to "Fred",
             "documentRequestFreeText" to "Please provide valid identity document",
+            "documentRejectionText" to "BIRTH_MINUS_CERTIFICATE\n\n* We were unable to read the document provided because it was not clear or not showing the information we needed\n\n----\n\n",
             "LAName" to "City of Sunderland",
             "eroWebsite" to "ero-address.com",
             "eroEmail" to "fred.blogs@some-domain.co.uk",
@@ -270,12 +274,24 @@ internal class GenerateIdDocumentResubmissionTemplatePreviewIntegrationTest : In
         val notifyClientResponse = NotifyGenerateTemplatePreviewSuccessResponse(id = DOCUMENT_TEMPLATE_ID)
         wireMockService.stubNotifyGenerateTemplatePreviewSuccessResponse(notifyClientResponse)
 
-        val requestBody = buildGenerateIdDocumentResubmissionTemplatePreviewRequest(sourceType = SourceTypeModel.VOTER_MINUS_CARD)
+        val requestBody = buildGenerateIdDocumentResubmissionTemplatePreviewRequest(
+            sourceType = SourceTypeModel.VOTER_MINUS_CARD,
+            personalisation = buildIdDocumentResubmissionPersonalisationRequest(
+                rejectedDocuments = listOf(
+                    buildRejectedDocument(
+                        documentType = DocumentType.BIRTH_MINUS_CERTIFICATE,
+                        rejectionReasons = listOf(DocumentRejectionReason.UNREADABLE_MINUS_DOCUMENT),
+                        rejectionNotes = "I can't read it"
+                    )
+                )
+            )
+        )
         val expectedPersonalisationDataMap = with(requestBody.personalisation) {
             mapOf(
                 "applicationReference" to applicationReference,
                 "firstName" to firstName,
                 "documentRequestFreeText" to idDocumentRequestFreeText,
+                "documentRejectionText" to "BIRTH_MINUS_CERTIFICATE\n\n* We were unable to read the document provided because it was not clear or not showing the information we needed\n\nI can't read it\n\n----\n\n",
                 "LAName" to eroContactDetails.localAuthorityName,
                 "eroWebsite" to eroContactDetails.website,
                 "eroEmail" to eroContactDetails.email,
@@ -316,7 +332,16 @@ internal class GenerateIdDocumentResubmissionTemplatePreviewIntegrationTest : In
         wireMockService.stubNotifyGenerateTemplatePreviewSuccessResponse(notifyClientResponse)
 
         val requestBody = buildGenerateIdDocumentResubmissionTemplatePreviewRequest(
-            personalisation = buildIdDocumentResubmissionPersonalisationRequest(eroContactDetails = buildContactDetailsRequest(address = buildAddressRequestWithOptionalParamsNull())),
+            personalisation = buildIdDocumentResubmissionPersonalisationRequest(
+                eroContactDetails = buildContactDetailsRequest(address = buildAddressRequestWithOptionalParamsNull()),
+                rejectedDocuments = listOf(
+                    buildRejectedDocument(
+                        documentType = DocumentType.BIRTH_MINUS_CERTIFICATE,
+                        rejectionReasons = listOf(DocumentRejectionReason.UNREADABLE_MINUS_DOCUMENT),
+                        rejectionNotes = null
+                    )
+                )
+            ),
             sourceType = SourceTypeModel.VOTER_MINUS_CARD
         )
         val expectedPersonalisationDataMap = with(requestBody.personalisation) {
@@ -324,6 +349,7 @@ internal class GenerateIdDocumentResubmissionTemplatePreviewIntegrationTest : In
                 "applicationReference" to applicationReference,
                 "firstName" to firstName,
                 "documentRequestFreeText" to idDocumentRequestFreeText,
+                "documentRejectionText" to "BIRTH_MINUS_CERTIFICATE\n\n* We were unable to read the document provided because it was not clear or not showing the information we needed\n\n----\n\n",
                 "LAName" to eroContactDetails.localAuthorityName,
                 "eroWebsite" to eroContactDetails.website,
                 "eroEmail" to eroContactDetails.email,

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/dto/TemplatePersonalisationDtoBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/dto/TemplatePersonalisationDtoBuilder.kt
@@ -41,13 +41,15 @@ fun buildIdDocumentPersonalisationDto(
     applicationReference: String = aValidApplicationReference(),
     firstName: String = faker.name().firstName(),
     idDocumentRequestFreeText: String = faker.harryPotter().spell(),
-    eroContactDetails: ContactDetailsDto = buildContactDetailsDto()
+    eroContactDetails: ContactDetailsDto = buildContactDetailsDto(),
+    documentRejectionText: String? = null,
 ): IdDocumentPersonalisationDto =
     IdDocumentPersonalisationDto(
         applicationReference = applicationReference,
         firstName = firstName,
         idDocumentRequestFreeText = idDocumentRequestFreeText,
-        eroContactDetails = eroContactDetails
+        eroContactDetails = eroContactDetails,
+        documentRejectionText = documentRejectionText,
     )
 
 fun buildIdDocumentRequiredPersonalisationDto(
@@ -135,13 +137,15 @@ fun buildPhotoPersonalisationDtoFromMessage(
 }
 
 fun buildIdDocumentPersonalisationDtoFromMessage(
-    personalisationMessage: IdDocumentPersonalisation
+    personalisationMessage: IdDocumentPersonalisation,
+    documentRejectionText: String? = null,
 ): IdDocumentPersonalisationDto {
     return with(personalisationMessage) {
         IdDocumentPersonalisationDto(
             applicationReference = applicationReference,
             firstName = firstName,
             idDocumentRequestFreeText = idDocumentRequestFreeText,
+            documentRejectionText = documentRejectionText,
             eroContactDetails = with(eroContactDetails) {
                 buildContactDetailsDto(
                     localAuthorityName = localAuthorityName,


### PR DESCRIPTION
This PR wires in `IdentityDocumentResubmissionDocumentRejectionTextMapper` to map rejected documents into `documentRejectionText`. which is then passed to gov.uk notify in the personalisation map!