### PR TITLE
EIP1-8103 Updating VAC and adding OAVA notifications API statistics endpoints

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -180,6 +180,12 @@ tasks.create("generate-models-from-openapi-document-vca-sqs-messaging-erop.yaml"
     packageName.set("uk.gov.dluhc.votercardapplicationsapi.messaging")
 }
 
+tasks.create("generate-models-from-openapi-document-postal-sqs-messaging-erop.yaml", GenerateTask::class) {
+    enabled = true
+    inputSpec.set("$projectDir/src/main/resources/openapi/sqs/postal-api-sqs-messaging-erop.yaml")
+    packageName.set("uk.gov.dluhc.postalapplicationsapi.messaging")
+}
+
 tasks.create("generate-models-from-openapi-document-EROManagementAPIs.yaml", GenerateTask::class) {
     enabled = true
     inputSpec.set("$projectDir/src/main/resources/openapi/external/EROManagementAPIs.yaml")

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/config/MessagingConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/config/MessagingConfiguration.kt
@@ -21,9 +21,16 @@ class MessagingConfiguration {
     @Value("\${sqs.trigger-voter-card-statistics-update-queue-name}")
     private lateinit var triggerVoterCardStatisticsUpdateQueueName: String
 
+    @Value("\${sqs.trigger-postal-application-statistics-update-queue-name}")
+    private lateinit var triggerPostalApplicationStatisticsUpdateQueueName: String
+
     @Bean
     fun triggerVoterCardStatisticsUpdateQueue(queueMessagingTemplate: QueueMessagingTemplate) =
         MessageQueue<UpdateStatisticsMessage>(triggerVoterCardStatisticsUpdateQueueName, queueMessagingTemplate)
+
+    @Bean
+    fun triggerPostalApplicationStatisticsUpdateQueue(queueMessagingTemplate: QueueMessagingTemplate) =
+        MessageQueue<UpdateStatisticsMessage>(triggerPostalApplicationStatisticsUpdateQueueName, queueMessagingTemplate)
 
     @Bean
     fun queueMessageHandlerFactory(

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/config/MessagingConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/config/MessagingConfiguration.kt
@@ -13,7 +13,8 @@ import org.springframework.messaging.handler.annotation.support.HeadersMethodArg
 import org.springframework.messaging.handler.annotation.support.PayloadMethodArgumentResolver
 import org.springframework.validation.Validator
 import uk.gov.dluhc.messagingsupport.MessageQueue
-import uk.gov.dluhc.votercardapplicationsapi.messaging.models.UpdateStatisticsMessage
+import uk.gov.dluhc.postalapplicationsapi.messaging.models.UpdateStatisticsMessage as PostalUpdateStatisticsMessage
+import uk.gov.dluhc.votercardapplicationsapi.messaging.models.UpdateStatisticsMessage as VoterCardUpdateStatisticsMessage
 
 @Configuration
 class MessagingConfiguration {
@@ -26,11 +27,11 @@ class MessagingConfiguration {
 
     @Bean
     fun triggerVoterCardStatisticsUpdateQueue(queueMessagingTemplate: QueueMessagingTemplate) =
-        MessageQueue<UpdateStatisticsMessage>(triggerVoterCardStatisticsUpdateQueueName, queueMessagingTemplate)
+        MessageQueue<VoterCardUpdateStatisticsMessage>(triggerVoterCardStatisticsUpdateQueueName, queueMessagingTemplate)
 
     @Bean
     fun triggerPostalApplicationStatisticsUpdateQueue(queueMessagingTemplate: QueueMessagingTemplate) =
-        MessageQueue<UpdateStatisticsMessage>(triggerPostalApplicationStatisticsUpdateQueueName, queueMessagingTemplate)
+        MessageQueue<PostalUpdateStatisticsMessage>(triggerPostalApplicationStatisticsUpdateQueueName, queueMessagingTemplate)
 
     @Bean
     fun queueMessageHandlerFactory(

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/config/SecurityConfiguration.kt
@@ -41,7 +41,7 @@ class SecurityConfiguration(
                     it.antMatchers("/actuator/**").permitAll()
 
                     // These requests are authenticated through the API gateway using IAM
-                    it.antMatchers("/communications/statistics").permitAll()
+                    it.antMatchers("/communications/statistics/**").permitAll()
                     it.anyRequest().authenticated()
                 }
                 .oauth2ResourceServer { oAuth2ResourceServerConfigurer ->

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/rest/StatisticsController.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/rest/StatisticsController.kt
@@ -2,12 +2,14 @@ package uk.gov.dluhc.notificationsapi.rest
 
 import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.dluhc.notificationsapi.dto.NotificationType
 import uk.gov.dluhc.notificationsapi.dto.SourceType
-import uk.gov.dluhc.notificationsapi.models.CommunicationsStatisticsResponse
+import uk.gov.dluhc.notificationsapi.models.CommunicationsStatisticsResponseOAVA
+import uk.gov.dluhc.notificationsapi.models.CommunicationsStatisticsResponseVAC
 import uk.gov.dluhc.notificationsapi.service.SentNotificationsService
 
 @RestController
@@ -16,11 +18,10 @@ import uk.gov.dluhc.notificationsapi.service.SentNotificationsService
 class StatisticsController(
     private val sentNotificationsService: SentNotificationsService,
 ) {
-
-    @GetMapping
+    @GetMapping("/vac")
     fun getVacCommunicationsStatistics(
         @RequestParam applicationId: String,
-    ): CommunicationsStatisticsResponse {
+    ): CommunicationsStatisticsResponseVAC {
         val notifications = sentNotificationsService.getNotificationsForApplication(
             sourceReference = applicationId,
             sourceType = SourceType.VOTER_CARD
@@ -34,8 +35,32 @@ class StatisticsController(
             )
         }
 
-        return CommunicationsStatisticsResponse(
+        return CommunicationsStatisticsResponseVAC(
             photoRequested = photoRequested,
+            identityDocumentsRequested = identityDocumentsRequested,
+        )
+    }
+
+    @GetMapping("/oava/{oavaService}")
+    fun getOAVACommunicationsStatistics(
+        @RequestParam applicationId: String,
+        @PathVariable oavaService: String,
+    ): CommunicationsStatisticsResponseOAVA {
+        val notifications = sentNotificationsService.getNotificationsForApplication(
+            sourceReference = applicationId,
+            sourceType = if (oavaService == "postal") SourceType.POSTAL else SourceType.PROXY
+        )
+
+        val signatureRequested = notifications.any { it.type == NotificationType.REQUESTED_SIGNATURE }
+        val identityDocumentsRequested = notifications.any {
+            it.type in listOf(
+                NotificationType.ID_DOCUMENT_REQUIRED,
+                NotificationType.ID_DOCUMENT_RESUBMISSION
+            )
+        }
+
+        return CommunicationsStatisticsResponseOAVA(
+            signatureRequested = signatureRequested,
             identityDocumentsRequested = identityDocumentsRequested,
         )
     }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/service/SendNotificationService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/service/SendNotificationService.kt
@@ -16,6 +16,7 @@ import uk.gov.dluhc.notificationsapi.dto.NotificationChannel.EMAIL
 import uk.gov.dluhc.notificationsapi.dto.NotificationChannel.LETTER
 import uk.gov.dluhc.notificationsapi.dto.NotificationType
 import uk.gov.dluhc.notificationsapi.dto.SendNotificationRequestDto
+import uk.gov.dluhc.notificationsapi.dto.SourceType
 import java.time.Clock
 import java.time.LocalDateTime
 import java.util.UUID
@@ -42,20 +43,29 @@ class SendNotificationService(
             val sentNotification = sendNotificationForChannel(requestDto, personalisationMap, notificationId, sentAt)
             saveSentMessageAndCreateAuditOrLogError(sentNotification)
             if (shouldSendApplicationStatisticsUpdate(requestDto)) {
-                statisticsUpdateService.triggerVoterCardStatisticsUpdate(requestDto.sourceReference)
+                statisticsUpdateService.triggerStatisticsUpdate(requestDto.sourceReference, requestDto.sourceType)
             }
         } catch (ex: GovNotifyNonRetryableException) {
             logger.warn("Non-retryable error returned from the Notify service: ${ex.message}")
         }
     }
 
-    private fun shouldSendApplicationStatisticsUpdate(requestDto: SendNotificationRequestDto): Boolean =
+    private fun shouldSendApplicationStatisticsUpdateForNotificationType(requestDto: SendNotificationRequestDto): Boolean =
         when (requestDto.notificationType) {
             NotificationType.ID_DOCUMENT_REQUIRED -> true
             NotificationType.ID_DOCUMENT_RESUBMISSION -> true
             NotificationType.ID_DOCUMENT_RESUBMISSION_WITH_REASONS -> true
             NotificationType.PHOTO_RESUBMISSION -> true
             NotificationType.PHOTO_RESUBMISSION_WITH_REASONS -> true
+            NotificationType.REQUESTED_SIGNATURE -> true
+            else -> false
+        }
+
+    private fun shouldSendApplicationStatisticsUpdate(requestDto: SendNotificationRequestDto) : Boolean =
+        when (requestDto.sourceType) {
+            SourceType.POSTAL -> shouldSendApplicationStatisticsUpdateForNotificationType(requestDto)
+            SourceType.VOTER_CARD -> shouldSendApplicationStatisticsUpdateForNotificationType(requestDto)
+            //TODO: EIP1-8742 Add proxy
             else -> false
         }
 

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/service/SendNotificationService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/service/SendNotificationService.kt
@@ -61,11 +61,11 @@ class SendNotificationService(
             else -> false
         }
 
-    private fun shouldSendApplicationStatisticsUpdate(requestDto: SendNotificationRequestDto) : Boolean =
+    private fun shouldSendApplicationStatisticsUpdate(requestDto: SendNotificationRequestDto): Boolean =
         when (requestDto.sourceType) {
             SourceType.POSTAL -> shouldSendApplicationStatisticsUpdateForNotificationType(requestDto)
             SourceType.VOTER_CARD -> shouldSendApplicationStatisticsUpdateForNotificationType(requestDto)
-            //TODO: EIP1-8742 Add proxy
+            // TODO: EIP1-8742 Add proxy
             else -> false
         }
 

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/service/StatisticsUpdateService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/service/StatisticsUpdateService.kt
@@ -2,20 +2,31 @@ package uk.gov.dluhc.notificationsapi.service
 
 import org.springframework.stereotype.Service
 import uk.gov.dluhc.messagingsupport.MessageQueue
+import uk.gov.dluhc.notificationsapi.dto.SourceType
 import uk.gov.dluhc.votercardapplicationsapi.messaging.models.UpdateStatisticsMessage
 import java.util.UUID
 
 @Service
 class StatisticsUpdateService(
-    private val triggerVoterCardStatisticsUpdateQueue: MessageQueue<UpdateStatisticsMessage>
+    private val triggerVoterCardStatisticsUpdateQueue: MessageQueue<UpdateStatisticsMessage>,
+    private val triggerPostalApplicationStatisticsUpdateQueue: MessageQueue<UpdateStatisticsMessage>
 ) {
-    fun triggerVoterCardStatisticsUpdate(applicationId: String) {
-        triggerVoterCardStatisticsUpdateQueue.submit(
-            UpdateStatisticsMessage(voterCardApplicationId = applicationId),
-            mapOf(
-                "message-group-id" to applicationId,
-                "message-deduplication-id" to UUID.randomUUID().toString(),
-            )
+    fun triggerStatisticsUpdate(applicationId: String, sourceType: SourceType) {
+        val deduplicationId = UUID.randomUUID().toString()
+        val updateMessage = UpdateStatisticsMessage(applicationId = applicationId)
+
+        when (sourceType) {
+            SourceType.VOTER_CARD -> triggerVoterCardStatisticsUpdateQueue.submit(updateMessage, createMap(applicationId, deduplicationId))
+            SourceType.POSTAL -> triggerPostalApplicationStatisticsUpdateQueue.submit(updateMessage, createMap(applicationId, deduplicationId))
+            // TODO: EIP1-8742 Add proxy update
+            else -> {}
+        }
+    }
+
+    fun createMap(applicationId: String, deduplicationId: String): Map<String, Any> {
+        return mapOf(
+            "message-group-id" to applicationId,
+            "message-deduplication-id" to deduplicationId
         )
     }
 }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/service/StatisticsUpdateService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/service/StatisticsUpdateService.kt
@@ -3,24 +3,34 @@ package uk.gov.dluhc.notificationsapi.service
 import org.springframework.stereotype.Service
 import uk.gov.dluhc.messagingsupport.MessageQueue
 import uk.gov.dluhc.notificationsapi.dto.SourceType
-import uk.gov.dluhc.votercardapplicationsapi.messaging.models.UpdateStatisticsMessage
 import java.util.UUID
+import uk.gov.dluhc.postalapplicationsapi.messaging.models.UpdateStatisticsMessage as PostalUpdateStatisticsMessage
+import uk.gov.dluhc.votercardapplicationsapi.messaging.models.UpdateStatisticsMessage as VoterCardUpdateStatisticsMessage
 
 @Service
 class StatisticsUpdateService(
-    private val triggerVoterCardStatisticsUpdateQueue: MessageQueue<UpdateStatisticsMessage>,
-    private val triggerPostalApplicationStatisticsUpdateQueue: MessageQueue<UpdateStatisticsMessage>
+    private val triggerVoterCardStatisticsUpdateQueue: MessageQueue<VoterCardUpdateStatisticsMessage>,
+    private val triggerPostalApplicationStatisticsUpdateQueue: MessageQueue<PostalUpdateStatisticsMessage>
 ) {
     fun triggerStatisticsUpdate(applicationId: String, sourceType: SourceType) {
         val deduplicationId = UUID.randomUUID().toString()
-        val updateMessage = UpdateStatisticsMessage(applicationId = applicationId)
 
         when (sourceType) {
-            SourceType.VOTER_CARD -> triggerVoterCardStatisticsUpdateQueue.submit(updateMessage, createMap(applicationId, deduplicationId))
-            SourceType.POSTAL -> triggerPostalApplicationStatisticsUpdateQueue.submit(updateMessage, createMap(applicationId, deduplicationId))
+            SourceType.VOTER_CARD -> submitToTriggerVoterCardStatisticsUpdateQueue(applicationId, deduplicationId)
+            SourceType.POSTAL -> submitToTriggerPostalApplicationStatisticsUpdateQueue(applicationId, deduplicationId)
             // TODO: EIP1-8742 Add proxy update
             else -> {}
         }
+    }
+
+    fun submitToTriggerPostalApplicationStatisticsUpdateQueue(applicationId: String, deduplicationId: String) {
+        val updateMessage = PostalUpdateStatisticsMessage(postalApplicationId = applicationId)
+        triggerPostalApplicationStatisticsUpdateQueue.submit(updateMessage, createMap(applicationId, deduplicationId))
+    }
+
+    fun submitToTriggerVoterCardStatisticsUpdateQueue(applicationId: String, deduplicationId: String) {
+        val updateMessage = VoterCardUpdateStatisticsMessage(voterCardApplicationId = applicationId)
+        triggerVoterCardStatisticsUpdateQueue.submit(updateMessage, createMap(applicationId, deduplicationId))
     }
 
     fun createMap(applicationId: String, deduplicationId: String): Map<String, Any> {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -123,6 +123,7 @@ sqs:
   send-uk-gov-notify-nino-not-matched-queue-name: ${SQS_SEND_UK_GOV_NOTIFY_NINO_NOT_MATCHED_QUEUE_NAME}
   remove-application-notifications-queue-name: ${SQS_REMOVE_APPLICATION_NOTIFICATIONS_QUEUE_NAME}
   trigger-voter-card-statistics-update-queue-name: ${SQS_TRIGGER_VOTER_CARD_STATISTICS_UPDATE_QUEUE_NAME}
+  trigger-postal-application-statistics-update-queue-name: ${SQS_TRIGGER_POSTAL_APPLICATION_STATISTICS_UPDATE_QUEUE_NAME}
 
 logging:
   pattern:

--- a/src/main/resources/openapi/NotificationsAPIs.yaml
+++ b/src/main/resources/openapi/NotificationsAPIs.yaml
@@ -213,9 +213,9 @@ paths:
         httpMethod: GET
 
   #
-  # Communications Statistics - anonymised statistics about communications for a VAC application
+  # Communications Statistics VAC - anonymised statistics about communications for a VAC application
   # --------------------------------------------------------------------------------
-  '/communications/statistics':
+  '/communications/statistics/vac':
     options:
       summary: CORS support
       description: |
@@ -267,15 +267,94 @@ paths:
           required: true
       responses:
         '200':
-          $ref: '#/components/responses/CommunicationsStatistics'
+          $ref: '#/components/responses/CommunicationsStatisticsVAC'
         '404':
           $ref: '#/components/responses/404ErrorResponse'
-      operationId: get-notification-statistics-by-application-id
+      operationId: get-notification-statistics-by-application-id-vac
       security:
         - awsIamAuthorizer: [ ]
       x-amazon-apigateway-integration:
         type: HTTP_PROXY
-        uri: '${base_uri}/voter-authority-certificates/communications/statistics'
+        uri: '${base_uri}/voter-authority-certificates/communications/statistics/vac'
+        responseParameters:
+          method.response.header.Access-Control-Allow-Headers: '''Content-Type,X-Amz-Date,Authorization,X-Api-Key'''
+          method.response.header.Access-Control-Allow-Methods: '''*'''
+          method.response.header.Access-Control-Allow-Origin: '''*'''
+        connectionType: VPC_LINK
+        connectionId: '${vpc_connection_id}'
+        httpMethod: GET
+
+  #
+  # Communications Statistics OAVA - anonymised statistics about communications for an OAVA application
+  # --------------------------------------------------------------------------------
+  '/communications/statistics/oava/{oavaService}':
+    parameters:
+      - name: oavaService
+        description: The OAVA service of the application (postal or proxy).
+        schema:
+          type: string
+        in: path
+        required: true
+    options:
+      summary: CORS support
+      description: |
+        Enable CORS by returning correct headers
+      tags:
+        - Statistics
+      responses:
+        200:
+          description: Default response for CORS method
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+            Access-Control-Allow-Methods:
+              schema:
+                type: string
+            Access-Control-Allow-Headers:
+              schema:
+                type: string
+          content: { }
+      x-amazon-apigateway-integration:
+        type: mock
+        requestTemplates:
+          application/json: |
+            {
+              "statusCode" : 200
+            }
+        responses:
+          default:
+            statusCode: "200"
+            responseParameters:
+              method.response.header.Access-Control-Allow-Headers: '''Content-Type,X-Amz-Date,Authorization,X-Api-Key'''
+              method.response.header.Access-Control-Allow-Methods: '''*'''
+              method.response.header.Access-Control-Allow-Origin: '''*'''
+            responseTemplates:
+              application/json: |
+                {}
+    get:
+      summary: Returns anonymised statistics about communications for an OAVA application
+      description: Returns anonymised statistics about communications for an OAVA application
+      tags:
+        - Statistics
+      parameters:
+        - name: applicationId
+          description: An identifier of an application
+          schema:
+            type: string
+          in: query
+          required: true
+      responses:
+        '200':
+          $ref: '#/components/responses/CommunicationsStatisticsOAVA'
+        '404':
+          $ref: '#/components/responses/404ErrorResponse'
+      operationId: get-notification-statistics-by-application-id-oava
+      security:
+        - awsIamAuthorizer: [ ]
+      x-amazon-apigateway-integration:
+        type: HTTP_PROXY
+        uri: '${base_uri}/communications/statistics/oava/{oavaService}'
         responseParameters:
           method.response.header.Access-Control-Allow-Headers: '''Content-Type,X-Amz-Date,Authorization,X-Api-Key'''
           method.response.header.Access-Control-Allow-Methods: '''*'''
@@ -1644,8 +1723,8 @@ components:
         - personalisation
         - sourceType
         - hasRestrictedDocumentsList
-    CommunicationsStatisticsResponse:
-      title: CommunicationsStatisticsResponse
+    CommunicationsStatisticsResponseVAC:
+      title: CommunicationsStatisticsResponseVAC
       description: response containing anonymised statistics about communications related to an application
       type: object
       properties:
@@ -1655,6 +1734,18 @@ components:
           type: boolean
       required:
         - photoRequested
+        - identityDocumentsRequested
+    CommunicationsStatisticsResponseOAVA:
+      title: CommunicationsStatisticsResponseOAVA
+      description: response containing anonymised statistics about communications related to an application
+      type: object
+      properties:
+        signatureRequested:
+          type: boolean
+        identityDocumentsRequested:
+          type: boolean
+      required:
+        - signatureRequested
         - identityDocumentsRequested
 
   #
@@ -1777,7 +1868,7 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/CommunicationConfirmationHistoryResponse'
-    CommunicationsStatistics:
+    CommunicationsStatisticsVAC:
       description: Response containing statistics about communications for an application
       headers:
         Access-Control-Allow-Origin:
@@ -1792,7 +1883,23 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/CommunicationsStatisticsResponse'
+            $ref: '#/components/schemas/CommunicationsStatisticsResponseVAC'
+    CommunicationsStatisticsOAVA:
+      description: Response containing statistics about communications for an application
+      headers:
+        Access-Control-Allow-Origin:
+          schema:
+            type: string
+        Access-Control-Allow-Methods:
+          schema:
+            type: string
+        Access-Control-Allow-Headers:
+          schema:
+            type: string
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CommunicationsStatisticsResponseOAVA'
 
 
   #

--- a/src/main/resources/openapi/sqs/postal-api-sqs-messaging-erop.yaml
+++ b/src/main/resources/openapi/sqs/postal-api-sqs-messaging-erop.yaml
@@ -1,11 +1,11 @@
 openapi: 3.0.0
 info:
-  title: Voter Card Application API SQS Message Types for EROP Clients
-  version: '1.5.1'
+  title: Postal Application API SQS Message Types for EROP Clients
+  version: '1.0.1'
   description: |-
-    Voter Card application API SQS Message Types for EROP Clients
+    Postal application API SQS Message Types for EROP Clients
     
-    Messages defined in this spec are produced by EROP (VCA and other apps) and consumed by VCA
+    Messages defined in this spec are produced by EROP (Postal and other apps) and consumed by Postal
     
     Whilst this is an openAPI spec, it does not imply being used to define REST APIs, nor is it intended to.
     
@@ -24,7 +24,7 @@ paths:
   # SQS Queues start here
   # --------------------------------------------------------------------------------
   #
-  '/move-certificate-photo':
+  '/erop-uploaded-application-identity-document-scan-result':
     post:
       tags:
         - SQS Queues
@@ -33,39 +33,21 @@ paths:
       responses:
         '204':
           description: No response content.
-  '/move-erop-uploaded-application-photo':
-    post:
-      tags:
-        - SQS Queues
-      requestBody:
-        $ref: '#/components/requestBodies/S3EventNotificationMessage'
-      responses:
-        '204':
-          description: No response content.
-  '/move-erop-uploaded-application-id-document':
-    post:
-      tags:
-        - SQS Queues
-      requestBody:
-        $ref: '#/components/requestBodies/S3EventNotificationMessage'
-      responses:
-        '204':
-          description: No response content.
-  '/remove-voter-card-application-data':
-    post:
-      tags:
-        - SQS Queues
-      requestBody:
-        $ref: '#/components/requestBodies/RemoveApplicationMessage'
-      responses:
-        '204':
-          description: No response content.
-  '/trigger-voter-card-statistics-update':
+  '/trigger-postal-application-statistics-update':
     post:
       tags:
         - SQS Queues
       requestBody:
         $ref: '#/components/requestBodies/UpdateStatisticsMessage'
+      responses:
+        '204':
+          description: No response content.
+  '/trigger-postal-application-reindex':
+    post:
+      tags:
+        - SQS Queues
+      requestBody:
+        $ref: '#/components/requestBodies/TriggerPostalApplicationReindexMessage'
       responses:
         '204':
           description: No response content.
@@ -193,13 +175,13 @@ components:
         name:
           type: string
           description: Bucket name from where this event came from
-          example: vca-example-source-bucket
+          example: postal-example-source-bucket
         ownerIdentity:
           $ref: '#/components/schemas/UserIdentity'
         arn:
           type: string
           description: S3Arn of the resource
-          example: arn:aws:s3:::vca-example-source-bucket
+          example: arn:aws:s3:::postal-example-source-bucket
       required:
         - name
     S3DetailObject:
@@ -245,28 +227,28 @@ components:
             lifecycleRestoreStorageClass:
               type: string
               description: Source storage class for restore
-    RemoveApplicationMessage:
-      title: RemoveApplicationMessage
-      type: object
-      description: SQS Message for initiating the removal of voter card application data within VCA.
-      properties:
-        voterCardApplicationId:
-          type: string
-          description: The identifier of the Voter Card Application
-          example: 1f0f76a9a66f438b9bb33070
-      required:
-        - voterCardApplicationId
     UpdateStatisticsMessage:
       title: UpdateStatisticsMessage
       type: object
-      description: SQS Message for initiating a statistics update for a voter card application.
+      description: SQS Message for initiating a statistics update for a postal application.
       properties:
-        voterCardApplicationId:
+        postalApplicationId:
           type: string
-          description: The identifier of the Voter Card Application
+          description: The identifier of the Postal Application
           example: 1f0f76a9a66f438b9bb33070
       required:
-        - voterCardApplicationId
+        - postalApplicationId
+    TriggerPostalApplicationReindexMessage:
+      title: TriggerPostalApplicationReindexMessage
+      type: object
+      description: SQS Message for triggering an indexing of a postal application.
+      properties:
+        applicationId:
+          type: string
+          description: The unique identifier of the Proxy Vote Application to reindex. A 24 character hex string.
+          example: 1f0f76a9a66f438b9bb33070
+      required:
+        - applicationId
 
   #
   # Response Body Definitions
@@ -282,11 +264,11 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/S3EventNotificationMessage'
-    RemoveApplicationMessage:
+    TriggerPostalApplicationReindexMessage:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/RemoveApplicationMessage'
+            $ref: '#/components/schemas/TriggerPostalApplicationReindexMessage'
     UpdateStatisticsMessage:
       content:
         application/json:

--- a/src/main/resources/openapi/sqs/vca-api-sqs-messaging-erop.yaml
+++ b/src/main/resources/openapi/sqs/vca-api-sqs-messaging-erop.yaml
@@ -1,9 +1,9 @@
 openapi: 3.0.0
 info:
-  title: Voter Card Application API SQS Message Types for EROP Clients
+  title: API SQS Message Types for EROP Clients
   version: '1.5.1'
   description: |-
-    Voter Card application API SQS Message Types for EROP Clients
+    API SQS Message Types for EROP Clients
     
     Messages defined in this spec are produced by EROP (VCA and other apps) and consumed by VCA
     
@@ -60,7 +60,7 @@ paths:
       responses:
         '204':
           description: No response content.
-  '/trigger-voter-card-statistics-update':
+  '/trigger-statistics-update':
     post:
       tags:
         - SQS Queues
@@ -248,25 +248,25 @@ components:
     RemoveApplicationMessage:
       title: RemoveApplicationMessage
       type: object
-      description: SQS Message for initiating the removal of voter card application data within VCA.
+      description: SQS Message for initiating the removal of application data.
       properties:
         voterCardApplicationId:
           type: string
-          description: The identifier of the Voter Card Application
+          description: The identifier of the Application
           example: 1f0f76a9a66f438b9bb33070
       required:
-        - voterCardApplicationId
+        - applicationId
     UpdateStatisticsMessage:
       title: UpdateStatisticsMessage
       type: object
-      description: SQS Message for initiating a statistics update for a voter card application.
+      description: SQS Message for initiating a statistics update for an application.
       properties:
-        voterCardApplicationId:
+        applicationId:
           type: string
-          description: The identifier of the Voter Card Application
+          description: The identifier of the Application
           example: 1f0f76a9a66f438b9bb33070
       required:
-        - voterCardApplicationId
+        - applicationId
 
   #
   # Response Body Definitions

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/config/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/config/IntegrationTest.kt
@@ -179,7 +179,7 @@ internal abstract class IntegrationTest {
         val messages = updateStatisticsMessageListenerStub.getMessages()
         Assertions.assertThat(messages).isNotEmpty
         Assertions.assertThat(messages).anyMatch {
-            it.voterCardApplicationId == applicationId
+            it.applicationId == applicationId
         }
     }
 

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/config/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/config/IntegrationTest.kt
@@ -22,7 +22,8 @@ import software.amazon.awssdk.services.dynamodb.model.ScanRequest
 import uk.gov.dluhc.notificationsapi.client.GovNotifyApiClient
 import uk.gov.dluhc.notificationsapi.database.repository.CommunicationConfirmationRepository
 import uk.gov.dluhc.notificationsapi.database.repository.NotificationRepository
-import uk.gov.dluhc.notificationsapi.stubs.UpdateStatisticsMessageListenerStub
+import uk.gov.dluhc.notificationsapi.stubs.UpdatePostalStatisticsMessageListenerStub
+import uk.gov.dluhc.notificationsapi.stubs.UpdateVoterCardStatisticsMessageListenerStub
 import uk.gov.dluhc.notificationsapi.testsupport.WiremockService
 import uk.gov.dluhc.notificationsapi.testsupport.getDifferentRandomEroId
 import uk.gov.dluhc.notificationsapi.testsupport.getRandomEroId
@@ -125,7 +126,10 @@ internal abstract class IntegrationTest {
     protected lateinit var idDocumentRequiredLetterWelshTemplateId: String
 
     @Autowired
-    protected lateinit var updateStatisticsMessageListenerStub: UpdateStatisticsMessageListenerStub
+    protected lateinit var updateVoterCardStatisticsMessageListenerStub: UpdateVoterCardStatisticsMessageListenerStub
+
+    @Autowired
+    protected lateinit var updatePostalStatisticsMessageListenerStub: UpdatePostalStatisticsMessageListenerStub
 
     @Autowired
     protected lateinit var objectMapper: ObjectMapper
@@ -152,7 +156,8 @@ internal abstract class IntegrationTest {
 
     @BeforeEach
     fun clearMessagesFromStubs() {
-        updateStatisticsMessageListenerStub.clear()
+        updateVoterCardStatisticsMessageListenerStub.clear()
+        updatePostalStatisticsMessageListenerStub.clear()
     }
 
     protected fun clearTable(tableName: String, partitionKey: String = "id", sortKey: String? = null) {
@@ -175,11 +180,19 @@ internal abstract class IntegrationTest {
         }
     }
 
-    protected fun assertUpdateStatisticsMessageSent(applicationId: String) {
-        val messages = updateStatisticsMessageListenerStub.getMessages()
+    protected fun assertVoterCardUpdateStatisticsMessageSent(applicationId: String) {
+        val messages = updateVoterCardStatisticsMessageListenerStub.getMessages()
         Assertions.assertThat(messages).isNotEmpty
         Assertions.assertThat(messages).anyMatch {
-            it.applicationId == applicationId
+            it.voterCardApplicationId == applicationId
+        }
+    }
+
+    protected fun assertPostalUpdateStatisticsMessageSent(applicationId: String) {
+        val messages = updatePostalStatisticsMessageListenerStub.getMessages()
+        Assertions.assertThat(messages).isNotEmpty
+        Assertions.assertThat(messages).anyMatch {
+            it.postalApplicationId == applicationId
         }
     }
 

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/config/LocalStackContainerConfiguration.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/config/LocalStackContainerConfiguration.kt
@@ -93,6 +93,7 @@ class LocalStackContainerConfiguration {
         @Value("\${sqs.send-uk-gov-notify-requested-signature-queue-name}") sendUkGovNotifyRequestedSignatureQueueName: String,
         @Value("\${sqs.send-uk-gov-notify-nino-not-matched-queue-name}") sendUkGovNotifyNinoNotMatchedQueueName: String,
         @Value("\${sqs.trigger-voter-card-statistics-update-queue-name}") triggerVoterCardStatisticsUpdateQueueName: String,
+        @Value("\${sqs.trigger-postal-application-statistics-update-queue-name}") triggerPostalApplicationStatisticsUpdateQueueName: String,
     ): LocalStackContainerSettings {
         val sendUkGovNotifyPhotoResubmissionMessageQueueName = localStackContainer.createSqsQueue(sendUkGovNotifyPhotoResubmissionQueueName)
         val sendUkGovNotifyIdDocumentResubmissionMessageQueueName = localStackContainer.createSqsQueue(sendUkGovNotifyIdDocumentResubmissionQueueName)
@@ -104,6 +105,7 @@ class LocalStackContainerConfiguration {
         val sendUkGovNotifyNinoNotMatchedMessageQueueName = localStackContainer.createSqsQueue(sendUkGovNotifyNinoNotMatchedQueueName)
         val removeApplicationNotificationsMessageQueueName = localStackContainer.createSqsQueue(removeApplicationNotificationsQueueName)
         val triggerVoterCardStatisticsMessageQueueName = localStackContainer.createSqsQueue(triggerVoterCardStatisticsUpdateQueueName)
+        val triggerPostalApplicationStatisticsMessageQueueName = localStackContainer.createSqsQueue(triggerPostalApplicationStatisticsUpdateQueueName)
         localStackContainer.createSqsQueue(sendUkGovNotifyRejectedSignatureQueueName)
         localStackContainer.createSqsQueue(sendUkGovNotifyRequestedSignatureQueueName)
 
@@ -123,6 +125,7 @@ class LocalStackContainerConfiguration {
             removeApplicationNotificationsQueueName = removeApplicationNotificationsMessageQueueName,
             sendUkGovNotifyNinoNotMatchedMessageQueueName = sendUkGovNotifyNinoNotMatchedMessageQueueName,
             triggerVoterCardStatisticsUpdateQueueName = triggerVoterCardStatisticsMessageQueueName,
+            triggerPostalApplicationStatisticsUpdateQueueName = triggerPostalApplicationStatisticsMessageQueueName,
         )
     }
 
@@ -249,6 +252,7 @@ data class LocalStackContainerSettings(
     val sendUkGovNotifyNinoNotMatchedMessageQueueName: String,
     val removeApplicationNotificationsQueueName: String,
     val triggerVoterCardStatisticsUpdateQueueName: String,
+    val triggerPostalApplicationStatisticsUpdateQueueName: String,
 ) {
     val mappedQueueUrlSendUkGovNotifyPhotoResubmissionQueueName: String = toMappedUrl(sendUkGovNotifyPhotoResubmissionQueueName, apiUrl)
     val mappedQueueUrlSendUkGovNotifyIdDocumentResubmissionQueueName: String = toMappedUrl(sendUkGovNotifyIdDocumentResubmissionQueueName, apiUrl)
@@ -260,6 +264,7 @@ data class LocalStackContainerSettings(
     val mappedQueueUrlRemoveApplicationNotificationsQueueName: String = toMappedUrl(removeApplicationNotificationsQueueName, apiUrl)
     val mappedQueueUrlSendUkGovNotifyNinoNotMatchedMessageQueueName: String = toMappedUrl(sendUkGovNotifyNinoNotMatchedMessageQueueName, apiUrl)
     val mappedQueueUrlTriggerVoterCardStatisticsUpdateQueueName: String = toMappedUrl(triggerVoterCardStatisticsUpdateQueueName, apiUrl)
+    val mappedQueueUrlTriggerPostalApplicationStatisticsUpdateQueueName: String = toMappedUrl(triggerPostalApplicationStatisticsUpdateQueueName, apiUrl)
 
     private fun toMappedUrl(rawUrlString: String, apiUrlString: String): String {
         val rawUrl = URI.create(rawUrlString)

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyIdDocumentRequiredMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyIdDocumentRequiredMessageListenerIntegrationTest.kt
@@ -58,7 +58,7 @@ internal class SendNotifyIdDocumentRequiredMessageListenerIntegrationTest : Inte
             assertThat(actualEntity).hasSize(1).element(0)
                 .extracting("sourceType", "type", "channel")
                 .containsExactlyInAnyOrder(VOTER_CARD, ID_DOCUMENT_REQUIRED, EMAIL)
-            assertUpdateStatisticsMessageSent(sourceReference)
+            assertVoterCardUpdateStatisticsMessageSent(sourceReference)
             stopWatch.stop()
             logger.info("completed assertions in $stopWatch for language $language")
         }
@@ -97,7 +97,7 @@ internal class SendNotifyIdDocumentRequiredMessageListenerIntegrationTest : Inte
             assertThat(actualEntity).hasSize(1).element(0)
                 .extracting("sourceType", "type", "channel")
                 .containsExactlyInAnyOrder(VOTER_CARD, ID_DOCUMENT_REQUIRED, LETTER)
-            assertUpdateStatisticsMessageSent(sourceReference)
+            assertVoterCardUpdateStatisticsMessageSent(sourceReference)
             stopWatch.stop()
             logger.info("completed assertions in $stopWatch for language $language")
         }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyIdDocumentResubmissionMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyIdDocumentResubmissionMessageListenerIntegrationTest.kt
@@ -54,7 +54,7 @@ internal class SendNotifyIdDocumentResubmissionMessageListenerIntegrationTest : 
             assertThat(actualEntity).hasSize(1).element(0)
                 .extracting("sourceType", "type", "channel")
                 .containsExactlyInAnyOrder(VOTER_CARD, ID_DOCUMENT_RESUBMISSION, EMAIL)
-            assertUpdateStatisticsMessageSent(sourceReference)
+            assertVoterCardUpdateStatisticsMessageSent(sourceReference)
             stopWatch.stop()
             logger.info("completed assertions in $stopWatch for language $language")
         }
@@ -89,7 +89,7 @@ internal class SendNotifyIdDocumentResubmissionMessageListenerIntegrationTest : 
             assertThat(actualEntity).hasSize(1).element(0)
                 .extracting("sourceType", "type", "channel")
                 .containsExactlyInAnyOrder(VOTER_CARD, ID_DOCUMENT_RESUBMISSION, LETTER)
-            assertUpdateStatisticsMessageSent(sourceReference)
+            assertVoterCardUpdateStatisticsMessageSent(sourceReference)
             stopWatch.stop()
             logger.info("completed assertions in $stopWatch for language $language")
         }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyPhotoResubmissionMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyPhotoResubmissionMessageListenerIntegrationTest.kt
@@ -49,7 +49,7 @@ internal class SendNotifyPhotoResubmissionMessageListenerIntegrationTest : Integ
             wireMockService.verifyNotifySendEmailCalled()
             val actualEntity = notificationRepository.getBySourceReferenceAndGssCode(sourceReference, VOTER_CARD, listOf(gssCode))
             assertThat(actualEntity).hasSize(1)
-            assertUpdateStatisticsMessageSent(sourceReference)
+            assertVoterCardUpdateStatisticsMessageSent(sourceReference)
             stopWatch.stop()
             logger.info("completed assertions in $stopWatch for language $language")
         }
@@ -82,7 +82,7 @@ internal class SendNotifyPhotoResubmissionMessageListenerIntegrationTest : Integ
             wireMockService.verifyNotifySendLetterCalled()
             val actualEntity = notificationRepository.getBySourceReferenceAndGssCode(sourceReference, VOTER_CARD, listOf(gssCode))
             assertThat(actualEntity).hasSize(1)
-            assertUpdateStatisticsMessageSent(sourceReference)
+            assertVoterCardUpdateStatisticsMessageSent(sourceReference)
             stopWatch.stop()
             logger.info("completed assertions in $stopWatch for language $language")
         }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyRequestedSignatureMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyRequestedSignatureMessageListenerIntegrationTest.kt
@@ -81,6 +81,10 @@ internal class SendNotifyRequestedSignatureMessageListenerIntegrationTest : Inte
             val actualEntity = notificationRepository
                 .getBySourceReferenceAndGssCode(sourceReference, expectedSourceType, listOf(gssCode))
             Assertions.assertThat(actualEntity).hasSize(1)
+            when (sourceType) { // TODO: EIP1-8742 Add proxy
+                SourceType.POSTAL -> assertPostalUpdateStatisticsMessageSent(sourceReference)
+                else -> {}
+            }
             stopWatch.stop()
             logger.info("completed assertions in $stopWatch for language $language and channel $sqsChannel")
         }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GetCommunicationStatisticsByApplicationIdIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GetCommunicationStatisticsByApplicationIdIntegrationTest.kt
@@ -5,7 +5,8 @@ import org.junit.jupiter.api.Test
 import uk.gov.dluhc.notificationsapi.config.IntegrationTest
 import uk.gov.dluhc.notificationsapi.database.entity.NotificationType
 import uk.gov.dluhc.notificationsapi.database.entity.SourceType
-import uk.gov.dluhc.notificationsapi.models.CommunicationsStatisticsResponse
+import uk.gov.dluhc.notificationsapi.models.CommunicationsStatisticsResponseOAVA
+import uk.gov.dluhc.notificationsapi.models.CommunicationsStatisticsResponseVAC
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aRandomSourceReference
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.database.entity.aNotificationBuilder
 import java.util.UUID
@@ -13,28 +14,28 @@ import java.util.UUID
 internal class GetCommunicationStatisticsByApplicationIdIntegrationTest : IntegrationTest() {
 
     @Test
-    fun `should return photo not requested and documents not requested for application with no communications sent`() {
+    fun `should return photo not requested and documents not requested for VAC application with no communications sent`() {
         // Given
         val applicationId = aRandomSourceReference()
 
-        val expected = CommunicationsStatisticsResponse(
+        val expected = CommunicationsStatisticsResponseVAC(
             photoRequested = false,
             identityDocumentsRequested = false
         )
 
         // When
         val response = webTestClient.get()
-            .uri(buildUri(applicationId = applicationId))
+            .uri(buildVacUri(applicationId = applicationId))
             .exchange()
 
         // Then
         response.expectStatus().isOk
-        val actual = response.returnResult(CommunicationsStatisticsResponse::class.java).responseBody.blockFirst()
+        val actual = response.returnResult(CommunicationsStatisticsResponseVAC::class.java).responseBody.blockFirst()
         assertThat(actual).isEqualTo(expected)
     }
 
     @Test
-    fun `should return photo not requested and documents not requested for application with no relevant communications sent`() {
+    fun `should return photo not requested and documents not requested for VAC application with no relevant communications sent`() {
         // Given
         val applicationId = aRandomSourceReference()
 
@@ -47,24 +48,24 @@ internal class GetCommunicationStatisticsByApplicationIdIntegrationTest : Integr
             sentNotification
         )
 
-        val expected = CommunicationsStatisticsResponse(
+        val expected = CommunicationsStatisticsResponseVAC(
             photoRequested = false,
             identityDocumentsRequested = false
         )
 
         // When
         val response = webTestClient.get()
-            .uri(buildUri(applicationId = applicationId))
+            .uri(buildVacUri(applicationId = applicationId))
             .exchange()
 
         // Then
         response.expectStatus().isOk
-        val actual = response.returnResult(CommunicationsStatisticsResponse::class.java).responseBody.blockFirst()
+        val actual = response.returnResult(CommunicationsStatisticsResponseVAC::class.java).responseBody.blockFirst()
         assertThat(actual).isEqualTo(expected)
     }
 
     @Test
-    fun `should return photo requested for application with photo resubmission communications sent`() {
+    fun `should return photo requested for VAC application with photo resubmission communications sent`() {
         // Given
         val applicationId = aRandomSourceReference()
 
@@ -77,24 +78,24 @@ internal class GetCommunicationStatisticsByApplicationIdIntegrationTest : Integr
             sentNotification
         )
 
-        val expected = CommunicationsStatisticsResponse(
+        val expected = CommunicationsStatisticsResponseVAC(
             photoRequested = true,
             identityDocumentsRequested = false
         )
 
         // When
         val response = webTestClient.get()
-            .uri(buildUri(applicationId = applicationId))
+            .uri(buildVacUri(applicationId = applicationId))
             .exchange()
 
         // Then
         response.expectStatus().isOk
-        val actual = response.returnResult(CommunicationsStatisticsResponse::class.java).responseBody.blockFirst()
+        val actual = response.returnResult(CommunicationsStatisticsResponseVAC::class.java).responseBody.blockFirst()
         assertThat(actual).isEqualTo(expected)
     }
 
     @Test
-    fun `should return identity document requested for application with id document resubmission communications sent`() {
+    fun `should return identity document requested for VAC application with id document resubmission communications sent`() {
         // Given
         val applicationId = aRandomSourceReference()
 
@@ -107,24 +108,24 @@ internal class GetCommunicationStatisticsByApplicationIdIntegrationTest : Integr
             sentNotification
         )
 
-        val expected = CommunicationsStatisticsResponse(
+        val expected = CommunicationsStatisticsResponseVAC(
             photoRequested = false,
             identityDocumentsRequested = true
         )
 
         // When
         val response = webTestClient.get()
-            .uri(buildUri(applicationId = applicationId))
+            .uri(buildVacUri(applicationId = applicationId))
             .exchange()
 
         // Then
         response.expectStatus().isOk
-        val actual = response.returnResult(CommunicationsStatisticsResponse::class.java).responseBody.blockFirst()
+        val actual = response.returnResult(CommunicationsStatisticsResponseVAC::class.java).responseBody.blockFirst()
         assertThat(actual).isEqualTo(expected)
     }
 
     @Test
-    fun `should return identity document requested for application with id document required communications sent`() {
+    fun `should return identity document requested for VAC application with id document required communications sent`() {
         // Given
         val applicationId = aRandomSourceReference()
 
@@ -137,22 +138,309 @@ internal class GetCommunicationStatisticsByApplicationIdIntegrationTest : Integr
             sentNotification
         )
 
-        val expected = CommunicationsStatisticsResponse(
+        val expected = CommunicationsStatisticsResponseVAC(
             photoRequested = false,
             identityDocumentsRequested = true
         )
 
         // When
         val response = webTestClient.get()
-            .uri(buildUri(applicationId = applicationId))
+            .uri(buildVacUri(applicationId = applicationId))
             .exchange()
 
         // Then
         response.expectStatus().isOk
-        val actual = response.returnResult(CommunicationsStatisticsResponse::class.java).responseBody.blockFirst()
+        val actual = response.returnResult(CommunicationsStatisticsResponseVAC::class.java).responseBody.blockFirst()
         assertThat(actual).isEqualTo(expected)
     }
 
-    private fun buildUri(applicationId: String = UUID.randomUUID().toString()) =
-        "/communications/statistics?applicationId=$applicationId"
+    @Test
+    fun `should return signature not requested and documents not requested for Postal application with no communications sent`() {
+        // Given
+        val applicationId = aRandomSourceReference()
+
+        val expected = CommunicationsStatisticsResponseOAVA(
+            signatureRequested = false,
+            identityDocumentsRequested = false
+        )
+
+        // When
+        val response = webTestClient.get()
+            .uri(buildOavaUri(applicationId = applicationId, "postal"))
+            .exchange()
+
+        // Then
+        response.expectStatus().isOk
+        val actualPostal = response.returnResult(CommunicationsStatisticsResponseOAVA::class.java).responseBody.blockFirst()
+        assertThat(actualPostal).isEqualTo(expected)
+    }
+
+    @Test
+    fun `should return signature not requested and documents not requested for Postal application with no relevant communications sent`() {
+        // Given
+        val applicationId = aRandomSourceReference()
+
+        val sentNotification = aNotificationBuilder(
+            sourceReference = applicationId,
+            sourceType = SourceType.POSTAL,
+            type = NotificationType.APPLICATION_APPROVED
+        )
+        notificationRepository.saveNotification(
+            sentNotification
+        )
+
+        val expected = CommunicationsStatisticsResponseOAVA(
+            signatureRequested = false,
+            identityDocumentsRequested = false
+        )
+
+        // When
+        val response = webTestClient.get()
+            .uri(buildOavaUri(applicationId = applicationId, "postal"))
+            .exchange()
+
+        // Then
+        response.expectStatus().isOk
+        val actual = response.returnResult(CommunicationsStatisticsResponseOAVA::class.java).responseBody.blockFirst()
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `should return signature requested for Postal application with signature resubmission communications sent`() {
+        // Given
+        val applicationId = aRandomSourceReference()
+
+        val sentNotification = aNotificationBuilder(
+            sourceReference = applicationId,
+            sourceType = SourceType.POSTAL,
+            type = NotificationType.REQUESTED_SIGNATURE
+        )
+
+        notificationRepository.saveNotification(
+            sentNotification
+        )
+
+        val expected = CommunicationsStatisticsResponseOAVA(
+            signatureRequested = true,
+            identityDocumentsRequested = false
+        )
+
+        // When
+        val response = webTestClient.get()
+            .uri(buildOavaUri(applicationId = applicationId, "postal"))
+            .exchange()
+
+        // Then
+        response.expectStatus().isOk
+        val actual = response.returnResult(CommunicationsStatisticsResponseOAVA::class.java).responseBody.blockFirst()
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `should return identity document requested for Postal application with id document resubmission communications sent`() {
+        // Given
+        val applicationId = aRandomSourceReference()
+
+        val sentNotification = aNotificationBuilder(
+            sourceReference = applicationId,
+            sourceType = SourceType.POSTAL,
+            type = NotificationType.ID_DOCUMENT_RESUBMISSION
+        )
+        notificationRepository.saveNotification(
+            sentNotification
+        )
+
+        val expected = CommunicationsStatisticsResponseOAVA(
+            signatureRequested = false,
+            identityDocumentsRequested = true
+        )
+
+        // When
+        val response = webTestClient.get()
+            .uri(buildOavaUri(applicationId = applicationId, "postal"))
+            .exchange()
+
+        // Then
+        response.expectStatus().isOk
+        val actual = response.returnResult(CommunicationsStatisticsResponseOAVA::class.java).responseBody.blockFirst()
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `should return identity document requested for Postal application with id document required communications sent`() {
+        // Given
+        val applicationId = aRandomSourceReference()
+
+        val sentNotification = aNotificationBuilder(
+            sourceReference = applicationId,
+            sourceType = SourceType.POSTAL,
+            type = NotificationType.ID_DOCUMENT_REQUIRED
+        )
+        notificationRepository.saveNotification(
+            sentNotification
+        )
+
+        val expected = CommunicationsStatisticsResponseOAVA(
+            signatureRequested = false,
+            identityDocumentsRequested = true
+        )
+
+        // When
+        val response = webTestClient.get()
+            .uri(buildOavaUri(applicationId = applicationId, "postal"))
+            .exchange()
+
+        // Then
+        response.expectStatus().isOk
+        val actual = response.returnResult(CommunicationsStatisticsResponseOAVA::class.java).responseBody.blockFirst()
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `should return signature not requested and documents not requested for Proxy application with no communications sent`() {
+        // Given
+        val applicationId = aRandomSourceReference()
+
+        val expected = CommunicationsStatisticsResponseOAVA(
+            signatureRequested = false,
+            identityDocumentsRequested = false
+        )
+
+        // When
+        val response = webTestClient.get()
+            .uri(buildOavaUri(applicationId = applicationId, "proxy"))
+            .exchange()
+
+        // Then
+        response.expectStatus().isOk
+        val actualPostal = response.returnResult(CommunicationsStatisticsResponseOAVA::class.java).responseBody.blockFirst()
+        assertThat(actualPostal).isEqualTo(expected)
+    }
+
+    @Test
+    fun `should return signature not requested and documents not requested for Proxy application with no relevant communications sent`() {
+        // Given
+        val applicationId = aRandomSourceReference()
+
+        val sentNotification = aNotificationBuilder(
+            sourceReference = applicationId,
+            sourceType = SourceType.PROXY,
+            type = NotificationType.APPLICATION_APPROVED
+        )
+        notificationRepository.saveNotification(
+            sentNotification
+        )
+
+        val expected = CommunicationsStatisticsResponseOAVA(
+            signatureRequested = false,
+            identityDocumentsRequested = false
+        )
+
+        // When
+        val response = webTestClient.get()
+            .uri(buildOavaUri(applicationId = applicationId, "proxy"))
+            .exchange()
+
+        // Then
+        response.expectStatus().isOk
+        val actual = response.returnResult(CommunicationsStatisticsResponseOAVA::class.java).responseBody.blockFirst()
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `should return signature requested for Proxy application with signature resubmission communications sent`() {
+        // Given
+        val applicationId = aRandomSourceReference()
+
+        val sentNotification = aNotificationBuilder(
+            sourceReference = applicationId,
+            sourceType = SourceType.PROXY,
+            type = NotificationType.REQUESTED_SIGNATURE
+        )
+
+        notificationRepository.saveNotification(
+            sentNotification
+        )
+
+        val expected = CommunicationsStatisticsResponseOAVA(
+            signatureRequested = true,
+            identityDocumentsRequested = false
+        )
+
+        // When
+        val response = webTestClient.get()
+            .uri(buildOavaUri(applicationId = applicationId, "proxy"))
+            .exchange()
+
+        // Then
+        response.expectStatus().isOk
+        val actual = response.returnResult(CommunicationsStatisticsResponseOAVA::class.java).responseBody.blockFirst()
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `should return identity document requested for Proxy application with id document resubmission communications sent`() {
+        // Given
+        val applicationId = aRandomSourceReference()
+
+        val sentNotification = aNotificationBuilder(
+            sourceReference = applicationId,
+            sourceType = SourceType.PROXY,
+            type = NotificationType.ID_DOCUMENT_RESUBMISSION
+        )
+        notificationRepository.saveNotification(
+            sentNotification
+        )
+
+        val expected = CommunicationsStatisticsResponseOAVA(
+            signatureRequested = false,
+            identityDocumentsRequested = true
+        )
+
+        // When
+        val response = webTestClient.get()
+            .uri(buildOavaUri(applicationId = applicationId, "proxy"))
+            .exchange()
+
+        // Then
+        response.expectStatus().isOk
+        val actual = response.returnResult(CommunicationsStatisticsResponseOAVA::class.java).responseBody.blockFirst()
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `should return identity document requested for Proxy application with id document required communications sent`() {
+        // Given
+        val applicationId = aRandomSourceReference()
+
+        val sentNotification = aNotificationBuilder(
+            sourceReference = applicationId,
+            sourceType = SourceType.PROXY,
+            type = NotificationType.ID_DOCUMENT_REQUIRED
+        )
+        notificationRepository.saveNotification(
+            sentNotification
+        )
+
+        val expected = CommunicationsStatisticsResponseOAVA(
+            signatureRequested = false,
+            identityDocumentsRequested = true
+        )
+
+        // When
+        val response = webTestClient.get()
+            .uri(buildOavaUri(applicationId = applicationId, "proxy"))
+            .exchange()
+
+        // Then
+        response.expectStatus().isOk
+        val actual = response.returnResult(CommunicationsStatisticsResponseOAVA::class.java).responseBody.blockFirst()
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    private fun buildVacUri(applicationId: String = UUID.randomUUID().toString()) =
+        "/communications/statistics/vac?applicationId=$applicationId"
+
+    private fun buildOavaUri(applicationId: String = UUID.randomUUID().toString(), oavaService: String) =
+        "/communications/statistics/oava/$oavaService?applicationId=$applicationId"
 }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/service/SendNotificationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/service/SendNotificationServiceTest.kt
@@ -209,11 +209,10 @@ internal class SendNotificationServiceTest {
     }
 
     @ParameterizedTest
-    @EnumSource(NotificationType::class, names = ["PHOTO_RESUBMISSION", "PHOTO_RESUBMISSION_WITH_REASONS", "ID_DOCUMENT_RESUBMISSION", "ID_DOCUMENT_RESUBMISSION_WITH_REASONS", "ID_DOCUMENT_REQUIRED"])
+    @EnumSource(NotificationType::class, names = ["PHOTO_RESUBMISSION", "PHOTO_RESUBMISSION_WITH_REASONS", "ID_DOCUMENT_RESUBMISSION", "ID_DOCUMENT_RESUBMISSION_WITH_REASONS", "ID_DOCUMENT_REQUIRED", "REQUESTED_SIGNATURE"])
     fun `should send statistics update for relevant notification types`(notificationType: NotificationType) {
 
         // Given
-        val channel = NotificationChannel.EMAIL
         val request = buildSendNotificationRequestDto(notificationType = notificationType)
         val personalisation = buildPhotoPersonalisationMapFromDto()
         val response = buildSendNotificationDto()
@@ -228,16 +227,58 @@ internal class SendNotificationServiceTest {
         sendNotificationService.sendNotification(request, personalisation)
 
         // Then
-        verify(statisticsUpdateService).triggerVoterCardStatisticsUpdate(notification.sourceReference!!)
+        verify(statisticsUpdateService).triggerStatisticsUpdate(notification.sourceReference!!, SourceType.VOTER_CARD)
     }
 
     @ParameterizedTest
-    @EnumSource(NotificationType::class, names = ["PHOTO_RESUBMISSION", "PHOTO_RESUBMISSION_WITH_REASONS", "ID_DOCUMENT_RESUBMISSION", "ID_DOCUMENT_RESUBMISSION_WITH_REASONS", "ID_DOCUMENT_REQUIRED"], mode = EnumSource.Mode.EXCLUDE)
+    @EnumSource(NotificationType::class, names = ["PHOTO_RESUBMISSION", "PHOTO_RESUBMISSION_WITH_REASONS", "ID_DOCUMENT_RESUBMISSION", "ID_DOCUMENT_RESUBMISSION_WITH_REASONS", "ID_DOCUMENT_REQUIRED", "REQUESTED_SIGNATURE"], mode = EnumSource.Mode.EXCLUDE)
     fun `should not send statistics update for irrelevant notification types`(notificationType: NotificationType) {
 
         // Given
-        val channel = NotificationChannel.EMAIL
         val request = buildSendNotificationRequestDto(notificationType = notificationType)
+        val personalisation = buildPhotoPersonalisationMapFromDto()
+        val response = buildSendNotificationDto()
+        val notification = aNotification()
+        val templateId = aTemplateId().toString()
+
+        given(notifyApiClient.sendEmail(any(), any(), any(), any())).willReturn(response)
+        given(notificationMapper.createNotification(any(), any(), any(), any(), any())).willReturn(notification)
+        given(notificationTemplateMapper.fromNotificationTypeForChannelInLanguage(any(), any(), any(), any())).willReturn(templateId)
+
+        // When
+        sendNotificationService.sendNotification(request, personalisation)
+
+        // Then
+        verifyNoInteractions(statisticsUpdateService)
+    }
+
+    @ParameterizedTest
+    @EnumSource(SourceType::class, names = ["VOTER_CARD", "POSTAL"]) //TODO: EIP1-8742 Add proxy
+    fun `should send statistics update for Postal and Voter Card applications`(sourceType: SourceType) {
+        // Given
+        val request = buildSendNotificationRequestDto(sourceType = sourceType, notificationType = NotificationType.ID_DOCUMENT_REQUIRED)
+        val personalisation = buildPhotoPersonalisationMapFromDto()
+        val response = buildSendNotificationDto()
+        val notification = aNotification()
+        val templateId = aTemplateId().toString()
+
+        given(notifyApiClient.sendEmail(any(), any(), any(), any())).willReturn(response)
+        given(notificationMapper.createNotification(any(), any(), any(), any(), any())).willReturn(notification)
+        given(notificationTemplateMapper.fromNotificationTypeForChannelInLanguage(any(), any(), any(), any())).willReturn(templateId)
+
+        // When
+        sendNotificationService.sendNotification(request, personalisation)
+
+        // Then
+        verify(statisticsUpdateService).triggerStatisticsUpdate(notification.sourceReference!!, sourceType)
+    }
+
+    @ParameterizedTest
+    @EnumSource(SourceType::class, names = ["VOTER_CARD", "POSTAL"], mode = EnumSource.Mode.EXCLUDE) //TODO: EIP1-8742 Add proxy
+    fun `should not send statistics update for irrelevant source types`(sourceType: SourceType) {
+
+        // Given
+        val request = buildSendNotificationRequestDto(sourceType = sourceType, notificationType = NotificationType.ID_DOCUMENT_REQUIRED)
         val personalisation = buildPhotoPersonalisationMapFromDto()
         val response = buildSendNotificationDto()
         val notification = aNotification()

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/service/SendNotificationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/service/SendNotificationServiceTest.kt
@@ -253,7 +253,7 @@ internal class SendNotificationServiceTest {
     }
 
     @ParameterizedTest
-    @EnumSource(SourceType::class, names = ["VOTER_CARD", "POSTAL"]) //TODO: EIP1-8742 Add proxy
+    @EnumSource(SourceType::class, names = ["VOTER_CARD", "POSTAL"]) // TODO: EIP1-8742 Add proxy
     fun `should send statistics update for Postal and Voter Card applications`(sourceType: SourceType) {
         // Given
         val request = buildSendNotificationRequestDto(sourceType = sourceType, notificationType = NotificationType.ID_DOCUMENT_REQUIRED)
@@ -274,7 +274,7 @@ internal class SendNotificationServiceTest {
     }
 
     @ParameterizedTest
-    @EnumSource(SourceType::class, names = ["VOTER_CARD", "POSTAL"], mode = EnumSource.Mode.EXCLUDE) //TODO: EIP1-8742 Add proxy
+    @EnumSource(SourceType::class, names = ["VOTER_CARD", "POSTAL"], mode = EnumSource.Mode.EXCLUDE) // TODO: EIP1-8742 Add proxy
     fun `should not send statistics update for irrelevant source types`(sourceType: SourceType) {
 
         // Given

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/service/StatisticsUpdateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/service/StatisticsUpdateServiceTest.kt
@@ -18,7 +18,8 @@ import org.mockito.kotlin.verifyNoMoreInteractions
 import uk.gov.dluhc.messagingsupport.MessageQueue
 import uk.gov.dluhc.notificationsapi.dto.SourceType
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aRandomSourceReference
-import uk.gov.dluhc.votercardapplicationsapi.messaging.models.UpdateStatisticsMessage
+import uk.gov.dluhc.postalapplicationsapi.messaging.models.UpdateStatisticsMessage as PostalUpdateStatisticsMessage
+import uk.gov.dluhc.votercardapplicationsapi.messaging.models.UpdateStatisticsMessage as VoterCardUpdateStatisticsMessage
 
 @ExtendWith(MockitoExtension::class)
 class StatisticsUpdateServiceTest {
@@ -26,17 +27,14 @@ class StatisticsUpdateServiceTest {
     @InjectMocks
     private lateinit var statisticsUpdateService: StatisticsUpdateService
 
-    @Mock
-    private lateinit var triggerUpdateStatisticsMessageQueue: MessageQueue<UpdateStatisticsMessage>
-
     @Captor
     private lateinit var headersArgumentCaptor: ArgumentCaptor<Map<String, Any>>
 
     @Mock
-    private lateinit var triggerVoterCardStatisticsUpdateQueue: MessageQueue<UpdateStatisticsMessage>
+    private lateinit var triggerVoterCardStatisticsUpdateQueue: MessageQueue<VoterCardUpdateStatisticsMessage>
 
     @Mock
-    private lateinit var triggerPostalApplicationStatisticsUpdateQueue: MessageQueue<UpdateStatisticsMessage>
+    private lateinit var triggerPostalApplicationStatisticsUpdateQueue: MessageQueue<PostalUpdateStatisticsMessage>
 
     @BeforeEach
     fun setUp() {
@@ -57,7 +55,7 @@ class StatisticsUpdateServiceTest {
 
         // Then
         verify(triggerVoterCardStatisticsUpdateQueue).submit(
-            eq(UpdateStatisticsMessage(applicationId)),
+            eq(VoterCardUpdateStatisticsMessage(applicationId)),
             any()
         )
         verifyNoMoreInteractions(triggerVoterCardStatisticsUpdateQueue)
@@ -87,7 +85,7 @@ class StatisticsUpdateServiceTest {
 
         // Then
         verify(triggerPostalApplicationStatisticsUpdateQueue).submit(
-            eq(UpdateStatisticsMessage(applicationId)),
+            eq(PostalUpdateStatisticsMessage(applicationId)),
             any()
         )
         verifyNoMoreInteractions(triggerPostalApplicationStatisticsUpdateQueue)
@@ -122,6 +120,6 @@ class StatisticsUpdateServiceTest {
         )
         assertThat(headersArgumentCaptor.value.get("message-group-id")).isEqualTo(applicationId)
         assertThat(headersArgumentCaptor.value.get("message-deduplication-id")).isNotNull
-        verifyNoMoreInteractions(triggerUpdateStatisticsMessageQueue)
+        verifyNoMoreInteractions(triggerVoterCardStatisticsUpdateQueue)
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/service/StatisticsUpdateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/service/StatisticsUpdateServiceTest.kt
@@ -14,6 +14,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import uk.gov.dluhc.messagingsupport.MessageQueue
+import uk.gov.dluhc.notificationsapi.dto.SourceType
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aRandomSourceReference
 import uk.gov.dluhc.votercardapplicationsapi.messaging.models.UpdateStatisticsMessage
 
@@ -36,7 +37,7 @@ class StatisticsUpdateServiceTest {
         val applicationId = aRandomSourceReference()
 
         // When
-        statisticsUpdateService.triggerVoterCardStatisticsUpdate(applicationId)
+        statisticsUpdateService.triggerStatisticsUpdate(applicationId, SourceType.VOTER_CARD)
 
         // Then
         verify(triggerUpdateStatisticsMessageQueue).submit(
@@ -53,7 +54,7 @@ class StatisticsUpdateServiceTest {
         val applicationId = aRandomSourceReference()
 
         // When
-        statisticsUpdateService.triggerVoterCardStatisticsUpdate(applicationId)
+        statisticsUpdateService.triggerStatisticsUpdate(applicationId, SourceType.VOTER_CARD)
 
         // Then
         verify(triggerUpdateStatisticsMessageQueue).submit(

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/stubs/UpdatePostalStatisticsMessageListenerStub.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/stubs/UpdatePostalStatisticsMessageListenerStub.kt
@@ -3,13 +3,13 @@ package uk.gov.dluhc.notificationsapi.stubs
 import io.awspring.cloud.messaging.listener.annotation.SqsListener
 import org.springframework.messaging.handler.annotation.Payload
 import org.springframework.stereotype.Component
-import uk.gov.dluhc.votercardapplicationsapi.messaging.models.UpdateStatisticsMessage
+import uk.gov.dluhc.postalapplicationsapi.messaging.models.UpdateStatisticsMessage
 import javax.validation.Valid
 
 @Component
-class UpdateStatisticsMessageListenerStub : MessageListenerStub<UpdateStatisticsMessage>() {
+class UpdatePostalStatisticsMessageListenerStub : MessageListenerStub<UpdateStatisticsMessage>() {
 
-    @SqsListener("\${sqs.trigger-voter-card-statistics-update-queue-name}")
+    @SqsListener("\${sqs.trigger-postal-application-statistics-update-queue-name}")
     override fun handleMessage(@Valid @Payload payload: UpdateStatisticsMessage) {
         super.handleMessage(payload)
     }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/stubs/UpdateVoterCardStatisticsMessageListenerStub.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/stubs/UpdateVoterCardStatisticsMessageListenerStub.kt
@@ -1,0 +1,16 @@
+package uk.gov.dluhc.notificationsapi.stubs
+
+import io.awspring.cloud.messaging.listener.annotation.SqsListener
+import org.springframework.messaging.handler.annotation.Payload
+import org.springframework.stereotype.Component
+import uk.gov.dluhc.votercardapplicationsapi.messaging.models.UpdateStatisticsMessage
+import javax.validation.Valid
+
+@Component
+class UpdateVoterCardStatisticsMessageListenerStub : MessageListenerStub<UpdateStatisticsMessage>() {
+
+    @SqsListener("\${sqs.trigger-voter-card-statistics-update-queue-name}")
+    override fun handleMessage(@Valid @Payload payload: UpdateStatisticsMessage) {
+        super.handleMessage(payload)
+    }
+}

--- a/src/test/resources/application-integration-test.yml
+++ b/src/test/resources/application-integration-test.yml
@@ -114,4 +114,4 @@ sqs:
   send-uk-gov-notify-nino-not-matched-queue-name: test-send-uk-gov-notify-nino-not-matched
   remove-application-notifications-queue-name: test-remove-application-notifications
   trigger-voter-card-statistics-update-queue-name: test-trigger-voter-card-statistics-update.fifo
-  trigger-postal-application-statistics-update-queue-name: trigger-postal-application-statistics-update.fifo
+  trigger-postal-application-statistics-update-queue-name: test-trigger-postal-application-statistics-update.fifo

--- a/src/test/resources/application-integration-test.yml
+++ b/src/test/resources/application-integration-test.yml
@@ -114,3 +114,4 @@ sqs:
   send-uk-gov-notify-nino-not-matched-queue-name: test-send-uk-gov-notify-nino-not-matched
   remove-application-notifications-queue-name: test-remove-application-notifications
   trigger-voter-card-statistics-update-queue-name: test-trigger-voter-card-statistics-update.fifo
+  trigger-postal-application-statistics-update-queue-name: trigger-postal-application-statistics-update.fifo


### PR DESCRIPTION
Updating /communication/statistics endpoint for Notifications API to track statistics for OAVA applications. 

**Note:** This will be a breaking change for VAC, so [VAC changes](https://github.com/communitiesuk/eip-ero-voter-card-applications-api/pull/762) must be released at the same time as this to avoid things breaking.