### PR TITLE
EIP1-8976: Change requiredDocumentFreeText to freeText

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/TemplatePersonalisationDtoMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/TemplatePersonalisationDtoMapper.kt
@@ -185,7 +185,7 @@ class TemplatePersonalisationDtoMapper {
         with(dto) {
             personalisation["applicationReference"] = applicationReference
             personalisation["firstName"] = firstName
-            personalisation["requiredDocumentFreeText"] = getSafeValue(requiredDocumentFreeText)
+            personalisation["freeText"] = getSafeValue(requiredDocumentFreeText)
             with(mutableMapOf<String, String>()) {
                 eroContactDetails.mapEroContactFields(this)
                 personalisation.putAll(this)

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GenerateRequiredOverseasDocumentTemplatePreviewIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GenerateRequiredOverseasDocumentTemplatePreviewIntegrationTest.kt
@@ -161,7 +161,7 @@ internal class GenerateRequiredOverseasDocumentTemplatePreviewIntegrationTest : 
             mapOf<String, Any>(
                 "applicationReference" to applicationReference,
                 "firstName" to firstName,
-                "requiredDocumentFreeText" to "",
+                "freeText" to "",
                 "LAName" to eroContactDetails.localAuthorityName,
                 "eroPhone" to eroContactDetails.phone,
                 "eroWebsite" to eroContactDetails.website,

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/dto/TemplatePersonalisationDtoBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/dto/TemplatePersonalisationDtoBuilder.kt
@@ -358,7 +358,7 @@ fun buildRequiredOverseasDocumentPersonalisationMapFromDto(
 ): Map<String, Any> {
     val personalisationMap = mutableMapOf<String, Any>()
     with(personalisationDto) {
-        personalisationMap["requiredDocumentFreeText"] = requiredDocumentFreeText ?: ""
+        personalisationMap["freeText"] = requiredDocumentFreeText ?: ""
         personalisationMap.putAll(getCommonDetailsMap(firstName, applicationReference, eroContactDetails))
     }
     return personalisationMap


### PR DESCRIPTION
Change requiredDocumentFreeText to freeText so that notify doesn't throw an error as it expects `freeText` placeholder