### PR TITLE
EIP1-9079: EROP OE implement document category for sqs queues

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/dto/DocumentCategoryDto.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/dto/DocumentCategoryDto.kt
@@ -1,6 +1,6 @@
 package uk.gov.dluhc.notificationsapi.dto
 
-enum class OverseasDocumentTypeDto(val value: String) {
+enum class DocumentCategoryDto(val value: String) {
     IDENTITY("identity"),
     PARENT_GUARDIAN("parent-guardian"),
     PREVIOUS_ADDRESS("previous-address")

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/dto/GenerateRejectedOverseasDocumentTemplatePreviewDto.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/dto/GenerateRejectedOverseasDocumentTemplatePreviewDto.kt
@@ -4,5 +4,5 @@ class GenerateRejectedOverseasDocumentTemplatePreviewDto(
     val channel: NotificationChannel,
     val language: LanguageDto,
     val personalisation: RejectedOverseasDocumentPersonalisationDto,
-    val overseasDocumentType: OverseasDocumentTypeDto
+    val documentCategory: DocumentCategoryDto
 )

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/dto/GenerateRequiredOverseasDocumentTemplatePreviewDto.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/dto/GenerateRequiredOverseasDocumentTemplatePreviewDto.kt
@@ -4,5 +4,5 @@ class GenerateRequiredOverseasDocumentTemplatePreviewDto(
     val channel: NotificationChannel,
     val language: LanguageDto,
     val personalisation: RequiredOverseasDocumentPersonalisationDto,
-    val overseasDocumentType: OverseasDocumentTypeDto
+    val documentCategory: DocumentCategoryDto
 )

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/DocumentCategoryMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/DocumentCategoryMapper.kt
@@ -2,24 +2,24 @@ package uk.gov.dluhc.notificationsapi.mapper
 
 import org.mapstruct.Mapper
 import org.mapstruct.ValueMapping
+import uk.gov.dluhc.notificationsapi.dto.DocumentCategoryDto
 import uk.gov.dluhc.notificationsapi.dto.NotificationType
-import uk.gov.dluhc.notificationsapi.dto.OverseasDocumentTypeDto
-import uk.gov.dluhc.notificationsapi.models.OverseasDocumentType
+import uk.gov.dluhc.notificationsapi.models.DocumentCategory
 
 @Mapper
-interface OverseasDocumentTypeMapper {
+interface DocumentCategoryMapper {
 
     @ValueMapping(source = "PARENT_MINUS_GUARDIAN", target = "PARENT_GUARDIAN")
     @ValueMapping(source = "PREVIOUS_MINUS_ADDRESS", target = "PREVIOUS_ADDRESS")
-    fun fromApiToDto(overseasDocumentType: OverseasDocumentType): OverseasDocumentTypeDto
+    fun fromApiToDto(documentCategory: DocumentCategory): DocumentCategoryDto
 
     @ValueMapping(source = "IDENTITY", target = "REJECTED_DOCUMENT")
     @ValueMapping(source = "PARENT_GUARDIAN", target = "REJECTED_PARENT_GUARDIAN")
     @ValueMapping(source = "PREVIOUS_ADDRESS", target = "REJECTED_PREVIOUS_ADDRESS")
-    fun fromRejectedOverseasDocumentTypeDtoToNotificationTypeDto(overseasDocumentType: OverseasDocumentTypeDto): NotificationType
+    fun fromRejectedOverseasDocumentCategoryDtoToNotificationTypeDto(documentCategory: DocumentCategoryDto): NotificationType
 
     @ValueMapping(source = "IDENTITY", target = "NINO_NOT_MATCHED")
     @ValueMapping(source = "PARENT_GUARDIAN", target = "PARENT_GUARDIAN_PROOF_REQUIRED")
     @ValueMapping(source = "PREVIOUS_ADDRESS", target = "PREVIOUS_ADDRESS_DOCUMENT_REQUIRED")
-    fun fromRequiredOverseasDocumentTypeDtoToNotificationTypeDto(overseasDocumentType: OverseasDocumentTypeDto): NotificationType
+    fun fromRequiredOverseasDocumentCategoryDtoToNotificationTypeDto(documentCategory: DocumentCategoryDto): NotificationType
 }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/RejectedOverseasDocumentTemplatePreviewDtoMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/RejectedOverseasDocumentTemplatePreviewDtoMapper.kt
@@ -13,7 +13,7 @@ class RejectedOverseasDocumentTemplatePreviewDtoMapper(
     private val notificationChannelMapper: NotificationChannelMapper,
     private val rejectedDocumentsMapper: RejectedDocumentsMapper,
     private val eroDtoMapper: EroDtoMapper,
-    private val overseasDocumentTypeMapper: OverseasDocumentTypeMapper
+    private val documentCategoryMapper: DocumentCategoryMapper
 ) {
 
     fun toRejectedOverseasDocumentTemplatePreviewDto(request: GenerateRejectedOverseasDocumentTemplatePreviewRequest): GenerateRejectedOverseasDocumentTemplatePreviewDto {
@@ -21,7 +21,7 @@ class RejectedOverseasDocumentTemplatePreviewDtoMapper(
             return GenerateRejectedOverseasDocumentTemplatePreviewDto(
                 channel = notificationChannelMapper.fromApiToDto(channel),
                 language = languageMapper.fromApiToDto(language!!),
-                overseasDocumentType = overseasDocumentTypeMapper.fromApiToDto(overseasDocumentType),
+                documentCategory = documentCategoryMapper.fromApiToDto(documentCategory),
                 personalisation = mapPersonalisation(personalisation, languageMapper.fromApiToDto(language))
             )
         }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/RequiredOverseasDocumentTemplatePreviewDtoMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/mapper/RequiredOverseasDocumentTemplatePreviewDtoMapper.kt
@@ -11,7 +11,7 @@ class RequiredOverseasDocumentTemplatePreviewDtoMapper(
     private val languageMapper: LanguageMapper,
     private val notificationChannelMapper: NotificationChannelMapper,
     private val eroDtoMapper: EroDtoMapper,
-    private val overseasDocumentTypeMapper: OverseasDocumentTypeMapper
+    private val documentCategoryMapper: DocumentCategoryMapper
 ) {
 
     fun toRequiredOverseasDocumentTemplatePreviewDto(request: GenerateRequiredOverseasDocumentTemplatePreviewRequest): GenerateRequiredOverseasDocumentTemplatePreviewDto {
@@ -19,7 +19,7 @@ class RequiredOverseasDocumentTemplatePreviewDtoMapper(
             return GenerateRequiredOverseasDocumentTemplatePreviewDto(
                 channel = notificationChannelMapper.fromApiToDto(channel),
                 language = languageMapper.fromApiToDto(language!!),
-                overseasDocumentType = overseasDocumentTypeMapper.fromApiToDto(overseasDocumentType),
+                documentCategory = documentCategoryMapper.fromApiToDto(documentCategory),
                 personalisation = mapPersonalisation(personalisation)
             )
         }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyNinoNotMatchedMessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyNinoNotMatchedMessageListener.kt
@@ -32,10 +32,12 @@ class SendNotifyNinoNotMatchedMessageListener(
                 "sourceReference: ${payload.sourceReference}"
         }
         with(payload) {
-            val sendNotificationRequestDto = sendNotifyMessageMapper.fromNinoNotMatchedMessageToSendNotificationRequestDto(this)
+            val sendNotificationRequestDto =
+                sendNotifyMessageMapper.fromNinoNotMatchedMessageToSendNotificationRequestDto(this)
             val personalisationDto = templatePersonalisationMessageMapper
                 .toNinoNotMatchedPersonalisationDto(personalisation, sendNotificationRequestDto.language, sourceType)
-            val personalisationMap = templatePersonalisationDtoMapper.toNinoNotMatchedTemplatePersonalisationMap(personalisationDto)
+            val personalisationMap =
+                templatePersonalisationDtoMapper.toNinoNotMatchedTemplatePersonalisationMap(personalisationDto)
             sendNotificationService.sendNotification(sendNotificationRequestDto, personalisationMap)
         }
     }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/service/TemplateService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/service/TemplateService.kt
@@ -17,7 +17,7 @@ import uk.gov.dluhc.notificationsapi.dto.RejectedSignatureTemplatePreviewDto
 import uk.gov.dluhc.notificationsapi.dto.RequestedSignatureTemplatePreviewDto
 import uk.gov.dluhc.notificationsapi.dto.SourceType
 import uk.gov.dluhc.notificationsapi.dto.api.NotifyTemplatePreviewDto
-import uk.gov.dluhc.notificationsapi.mapper.OverseasDocumentTypeMapper
+import uk.gov.dluhc.notificationsapi.mapper.DocumentCategoryMapper
 import uk.gov.dluhc.notificationsapi.mapper.TemplatePersonalisationDtoMapper
 
 @Service
@@ -25,7 +25,7 @@ class TemplateService(
     private val govNotifyApiClient: GovNotifyApiClient,
     private val templatePersonalisationDtoMapper: TemplatePersonalisationDtoMapper,
     private val notificationTemplateMapper: NotificationTemplateMapper,
-    private val overseasDocumentTypeMapper: OverseasDocumentTypeMapper
+    private val documentCategoryMapper: DocumentCategoryMapper
 ) {
 
     fun generatePhotoResubmissionTemplatePreview(request: GeneratePhotoResubmissionTemplatePreviewDto): NotifyTemplatePreviewDto {
@@ -173,8 +173,8 @@ class TemplateService(
             govNotifyApiClient.generateTemplatePreview(
                 notificationTemplateMapper.fromNotificationTypeForChannelInLanguage(
                     sourceType = SourceType.OVERSEAS,
-                    notificationType = overseasDocumentTypeMapper.fromRejectedOverseasDocumentTypeDtoToNotificationTypeDto(
-                        overseasDocumentType
+                    notificationType = documentCategoryMapper.fromRejectedOverseasDocumentCategoryDtoToNotificationTypeDto(
+                        documentCategory
                     ),
                     channel,
                     language
@@ -189,8 +189,8 @@ class TemplateService(
             govNotifyApiClient.generateTemplatePreview(
                 notificationTemplateMapper.fromNotificationTypeForChannelInLanguage(
                     sourceType = SourceType.OVERSEAS,
-                    notificationType = overseasDocumentTypeMapper.fromRequiredOverseasDocumentTypeDtoToNotificationTypeDto(
-                        overseasDocumentType
+                    notificationType = documentCategoryMapper.fromRequiredOverseasDocumentCategoryDtoToNotificationTypeDto(
+                        documentCategory
                     ),
                     channel,
                     language

--- a/src/main/resources/openapi/NotificationsAPIs.yaml
+++ b/src/main/resources/openapi/NotificationsAPIs.yaml
@@ -1207,9 +1207,9 @@ components:
         - postal
         - proxy
         - overseas
-    OverseasDocumentType:
-      title: OverseasDocumentType
-      description: The type of the overseas document
+    DocumentCategory:
+      title: DocumentCategory
+      description: The category of the document
       type: string
       enum:
         - identity
@@ -1373,13 +1373,13 @@ components:
           $ref: '#/components/schemas/Language'
         personalisation:
           $ref: '#/components/schemas/RejectedOverseasDocumentPersonalisation'
-        overseasDocumentType:
-          $ref: '#/components/schemas/OverseasDocumentType'
+        documentCategory:
+          $ref: '#/components/schemas/DocumentCategory'
       required:
         - channel
         - personalisation
         - sourceType
-        - overseasDocumentType
+        - documentCategory
     GenerateRequiredOverseasDocumentTemplatePreviewRequest:
       title: GenerateRequiredOverseasDocumentTemplatePreviewRequest
       description: An object containing request attributes required for generating the relevant required document template preview
@@ -1391,13 +1391,13 @@ components:
           $ref: '#/components/schemas/Language'
         personalisation:
           $ref: '#/components/schemas/RequiredOverseasDocumentPersonalisation'
-        overseasDocumentType:
-          $ref: '#/components/schemas/OverseasDocumentType'
+        documentCategory:
+          $ref: '#/components/schemas/DocumentCategory'
       required:
         - channel
         - personalisation
         - sourceType
-        - overseasDocumentType
+        - documentCategory
     IdDocumentPersonalisation:
       title: IdDocumentPersonalisation
       type: object

--- a/src/main/resources/openapi/NotificationsAPIs.yaml
+++ b/src/main/resources/openapi/NotificationsAPIs.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Notifications APIs
-  version: '1.15.1'
+  version: '1.15.2'
   description: Notifications APIs
   contact:
     name: Krister Bone

--- a/src/main/resources/openapi/sqs/Notifications-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/Notifications-sqs-messaging.yaml
@@ -259,6 +259,8 @@ components:
           $ref: '#/components/schemas/NotificationChannel'
         personalisation:
           $ref: '#/components/schemas/RejectedDocumentPersonalisation'
+        documentCategory:
+          $ref: '#/components/schemas/DocumentCategory'
       required:
         - channel
         - personalisation
@@ -499,6 +501,16 @@ components:
         - email
         - letter
 
+    DocumentCategory:
+      title: DocumentCategory
+      description: The category of the document
+      type: string
+      enum:
+        - identity
+        - parent-guardian
+        - previous-address
+      default: identity
+
     SourceType:
       title: SourceType
       type: string
@@ -723,10 +735,13 @@ components:
         hasRestrictedDocumentsList:
           type: boolean
           description: Whether the applicant this message is addressed to has a restricted documents list or not
+        documentCategory:
+          $ref: '#/components/schemas/DocumentCategory'
       required:
         - personalisation
         - channel
         - hasRestrictedDocumentsList
+
   #
   # Response Body Definitions
   # --------------------------------------------------------------------------------

--- a/src/main/resources/openapi/sqs/Notifications-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/Notifications-sqs-messaging.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Notifications SQS Message Types
-  version: '1.13.1'
+  version: '1.13.2'
   description: |-
     Notifications SQS Message Types
     

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/DocumentCategoryMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/DocumentCategoryMapperTest.kt
@@ -3,13 +3,13 @@ package uk.gov.dluhc.notificationsapi.mapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
+import uk.gov.dluhc.notificationsapi.dto.DocumentCategoryDto
 import uk.gov.dluhc.notificationsapi.dto.NotificationType
-import uk.gov.dluhc.notificationsapi.dto.OverseasDocumentTypeDto
-import uk.gov.dluhc.notificationsapi.models.OverseasDocumentType
+import uk.gov.dluhc.notificationsapi.models.DocumentCategory
 
-class OverseasDocumentTypeMapperTest {
+class DocumentCategoryMapperTest {
 
-    private val mapper = OverseasDocumentTypeMapperImpl()
+    private val mapper = DocumentCategoryMapperImpl()
 
     @ParameterizedTest
     @CsvSource(
@@ -20,13 +20,13 @@ class OverseasDocumentTypeMapperTest {
         ]
     )
     fun `should map from overseas document type API to overseas document type DTO`(
-        overseasDocumentTypeApi: OverseasDocumentType,
-        expected: OverseasDocumentTypeDto
+        documentCategoryApi: DocumentCategory,
+        expected: DocumentCategoryDto
     ) {
         // Given
 
         // When
-        val actual = mapper.fromApiToDto(overseasDocumentTypeApi)
+        val actual = mapper.fromApiToDto(documentCategoryApi)
 
         // Then
         assertThat(actual).isEqualTo(expected)
@@ -41,13 +41,13 @@ class OverseasDocumentTypeMapperTest {
         ]
     )
     fun `should map rejected overseas document to notification type`(
-        overseasDocumentTypeDto: OverseasDocumentTypeDto,
+        documentCategoryDto: DocumentCategoryDto,
         expected: NotificationType
     ) {
         // Given
 
         // When
-        val actual = mapper.fromRejectedOverseasDocumentTypeDtoToNotificationTypeDto(overseasDocumentTypeDto)
+        val actual = mapper.fromRejectedOverseasDocumentCategoryDtoToNotificationTypeDto(documentCategoryDto)
 
         // Then
         assertThat(actual).isEqualTo(expected)
@@ -62,13 +62,13 @@ class OverseasDocumentTypeMapperTest {
         ]
     )
     fun `should map required overseas document to notification type`(
-        overseasDocumentTypeDto: OverseasDocumentTypeDto,
+        documentCategoryDto: DocumentCategoryDto,
         expected: NotificationType
     ) {
         // Given
 
         // When
-        val actual = mapper.fromRequiredOverseasDocumentTypeDtoToNotificationTypeDto(overseasDocumentTypeDto)
+        val actual = mapper.fromRequiredOverseasDocumentCategoryDtoToNotificationTypeDto(documentCategoryDto)
 
         // Then
         assertThat(actual).isEqualTo(expected)

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/RejectedOverseasDocumentTemplatePreviewDtoMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/RejectedOverseasDocumentTemplatePreviewDtoMapperTest.kt
@@ -9,13 +9,13 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.given
+import uk.gov.dluhc.notificationsapi.dto.DocumentCategoryDto
 import uk.gov.dluhc.notificationsapi.dto.GenerateRejectedOverseasDocumentTemplatePreviewDto
 import uk.gov.dluhc.notificationsapi.dto.LanguageDto
-import uk.gov.dluhc.notificationsapi.dto.OverseasDocumentTypeDto
 import uk.gov.dluhc.notificationsapi.dto.RejectedOverseasDocumentPersonalisationDto
+import uk.gov.dluhc.notificationsapi.models.DocumentCategory
 import uk.gov.dluhc.notificationsapi.models.Language
 import uk.gov.dluhc.notificationsapi.models.NotificationChannel
-import uk.gov.dluhc.notificationsapi.models.OverseasDocumentType
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.buildAddressDto
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.buildContactDetailsDto
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.models.buildRejectedOverseasDocumentTemplatePreviewRequest
@@ -34,7 +34,7 @@ class RejectedOverseasDocumentTemplatePreviewDtoMapperTest {
     private lateinit var notificationChannelMapper: NotificationChannelMapper
 
     @Mock
-    private lateinit var overseasDocumentTypeMapper: OverseasDocumentTypeMapper
+    private lateinit var documentCategoryMapper: DocumentCategoryMapper
 
     @Mock
     private lateinit var rejectedDocumentsMapper: RejectedDocumentsMapper
@@ -49,14 +49,14 @@ class RejectedOverseasDocumentTemplatePreviewDtoMapperTest {
         "PREVIOUS_MINUS_ADDRESS, PREVIOUS_ADDRESS"
     )
     fun `should map rejected parent guardian template request to dto`(
-        overseasDocumentType: OverseasDocumentType,
-        overseasDocumentTypeDto: OverseasDocumentTypeDto
+        documentCategory: DocumentCategory,
+        documentCategoryDto: DocumentCategoryDto
     ) {
         // Given
         val request = buildRejectedOverseasDocumentTemplatePreviewRequest(
             language = Language.EN,
             channel = NotificationChannel.EMAIL,
-            overseasDocumentType = overseasDocumentType
+            documentCategory = documentCategory
         )
         val contactDetailsDto =
             with(request.personalisation.eroContactDetails) {
@@ -80,13 +80,13 @@ class RejectedOverseasDocumentTemplatePreviewDtoMapperTest {
 
         given(languageMapper.fromApiToDto(any())).willReturn(LanguageDto.ENGLISH)
         given(notificationChannelMapper.fromApiToDto(any())).willReturn(uk.gov.dluhc.notificationsapi.dto.NotificationChannel.EMAIL)
-        given(overseasDocumentTypeMapper.fromApiToDto(any())).willReturn(overseasDocumentTypeDto)
+        given(documentCategoryMapper.fromApiToDto(any())).willReturn(documentCategoryDto)
         given(rejectedDocumentsMapper.mapRejectionDocumentsFromApi(any(), any())).willReturn(listOf("doc1", "doc2"))
         given(eroDtoMapper.toContactDetailsDto(any())).willReturn(contactDetailsDto)
 
         val expected = GenerateRejectedOverseasDocumentTemplatePreviewDto(
             language = LanguageDto.ENGLISH,
-            overseasDocumentType = overseasDocumentTypeDto,
+            documentCategory = documentCategoryDto,
             personalisation = with(request.personalisation) {
                 RejectedOverseasDocumentPersonalisationDto(
                     applicationReference = applicationReference,

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GenerateRejectedOverseasDocumentTemplatePreviewIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GenerateRejectedOverseasDocumentTemplatePreviewIntegrationTest.kt
@@ -10,12 +10,12 @@ import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.test.web.reactive.server.WebTestClient
 import reactor.core.publisher.Mono
 import uk.gov.dluhc.notificationsapi.config.IntegrationTest
+import uk.gov.dluhc.notificationsapi.models.DocumentCategory
 import uk.gov.dluhc.notificationsapi.models.ErrorResponse
 import uk.gov.dluhc.notificationsapi.models.GenerateRejectedOverseasDocumentTemplatePreviewRequest
 import uk.gov.dluhc.notificationsapi.models.GenerateTemplatePreviewResponse
 import uk.gov.dluhc.notificationsapi.models.Language
 import uk.gov.dluhc.notificationsapi.models.NotificationChannel
-import uk.gov.dluhc.notificationsapi.models.OverseasDocumentType
 import uk.gov.dluhc.notificationsapi.testsupport.assertj.assertions.models.ErrorResponseAssert
 import uk.gov.dluhc.notificationsapi.testsupport.bearerToken
 import uk.gov.dluhc.notificationsapi.testsupport.model.NotifyGenerateTemplatePreviewSuccessResponse
@@ -80,7 +80,7 @@ internal class GenerateRejectedOverseasDocumentTemplatePreviewIntegrationTest : 
     )
     fun `should return not found given non existing template`(
         templateId: String,
-        overseasDocumentType: OverseasDocumentType
+        documentCategory: DocumentCategory
     ) {
         // Given
         wireMockService.stubNotifyGenerateTemplatePreviewNotFoundResponse(
@@ -94,7 +94,7 @@ internal class GenerateRejectedOverseasDocumentTemplatePreviewIntegrationTest : 
             .uri(URI_TEMPLATE)
             .bearerToken(getBearerToken())
             .contentType(APPLICATION_JSON)
-            .withAValidBody(overseasDocumentType)
+            .withAValidBody(documentCategory)
             .exchange()
             .expectStatus()
             .isNotFound
@@ -129,7 +129,7 @@ internal class GenerateRejectedOverseasDocumentTemplatePreviewIntegrationTest : 
     )
     fun `should return template preview given valid json request`(
         templateId: String,
-        overseasDocumentType: OverseasDocumentType,
+        documentCategory: DocumentCategory,
         channel: NotificationChannel,
         language: Language
     ) {
@@ -141,7 +141,7 @@ internal class GenerateRejectedOverseasDocumentTemplatePreviewIntegrationTest : 
         val requestBody = buildRejectedOverseasDocumentTemplatePreviewRequest(
             channel = channel,
             language = language,
-            overseasDocumentType = overseasDocumentType,
+            documentCategory = documentCategory,
             personalisation = buildRejectedOverseasDocumentPersonalisation(
                 documents = listOf(buildRejectedDocument(rejectionReasons = emptyList(), rejectionNotes = null)),
                 applicationReference = "applicationReference",
@@ -200,8 +200,8 @@ internal class GenerateRejectedOverseasDocumentTemplatePreviewIntegrationTest : 
     }
 }
 
-private fun WebTestClient.RequestBodySpec.withAValidBody(overseasDocumentType: OverseasDocumentType): WebTestClient.RequestBodySpec =
+private fun WebTestClient.RequestBodySpec.withAValidBody(documentCategory: DocumentCategory): WebTestClient.RequestBodySpec =
     body(
-        Mono.just(buildRejectedOverseasDocumentTemplatePreviewRequest(overseasDocumentType = overseasDocumentType)),
+        Mono.just(buildRejectedOverseasDocumentTemplatePreviewRequest(documentCategory = documentCategory)),
         GenerateRejectedOverseasDocumentTemplatePreviewRequest::class.java
     ) as WebTestClient.RequestBodySpec

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GenerateRequiredOverseasDocumentTemplatePreviewIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GenerateRequiredOverseasDocumentTemplatePreviewIntegrationTest.kt
@@ -9,13 +9,13 @@ import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
 import reactor.core.publisher.Mono
 import uk.gov.dluhc.notificationsapi.config.IntegrationTest
+import uk.gov.dluhc.notificationsapi.models.DocumentCategory
 import uk.gov.dluhc.notificationsapi.models.ErrorResponse
 import uk.gov.dluhc.notificationsapi.models.GenerateRejectedOverseasDocumentTemplatePreviewRequest
 import uk.gov.dluhc.notificationsapi.models.GenerateRequiredOverseasDocumentTemplatePreviewRequest
 import uk.gov.dluhc.notificationsapi.models.GenerateTemplatePreviewResponse
 import uk.gov.dluhc.notificationsapi.models.Language
 import uk.gov.dluhc.notificationsapi.models.NotificationChannel
-import uk.gov.dluhc.notificationsapi.models.OverseasDocumentType
 import uk.gov.dluhc.notificationsapi.testsupport.assertj.assertions.models.ErrorResponseAssert
 import uk.gov.dluhc.notificationsapi.testsupport.bearerToken
 import uk.gov.dluhc.notificationsapi.testsupport.model.NotifyGenerateTemplatePreviewSuccessResponse
@@ -83,7 +83,7 @@ internal class GenerateRequiredOverseasDocumentTemplatePreviewIntegrationTest : 
     )
     fun `should return not found given non existing template`(
         templateId: String,
-        overseasDocumentType: OverseasDocumentType
+        documentCategory: DocumentCategory
     ) {
         // Given
         wireMockService.stubNotifyGenerateTemplatePreviewNotFoundResponse(
@@ -97,7 +97,7 @@ internal class GenerateRequiredOverseasDocumentTemplatePreviewIntegrationTest : 
             .uri(URI_TEMPLATE)
             .bearerToken(getBearerToken())
             .contentType(MediaType.APPLICATION_JSON)
-            .withAValidBody(overseasDocumentType)
+            .withAValidBody(documentCategory)
             .exchange()
             .expectStatus()
             .isNotFound
@@ -132,7 +132,7 @@ internal class GenerateRequiredOverseasDocumentTemplatePreviewIntegrationTest : 
     )
     fun `should return template preview given valid json request`(
         templateId: String,
-        overseasDocumentType: OverseasDocumentType,
+        documentCategory: DocumentCategory,
         channel: NotificationChannel,
         language: Language
     ) {
@@ -144,7 +144,7 @@ internal class GenerateRequiredOverseasDocumentTemplatePreviewIntegrationTest : 
         val requestBody = buildRequiredOverseasDocumentTemplatePreviewRequest(
             channel = channel,
             language = language,
-            overseasDocumentType = overseasDocumentType,
+            documentCategory = documentCategory,
             personalisation = buildRequiredOverseasDocumentPersonalisation(
                 applicationReference = "applicationReference",
                 eroContactDetails = buildEroContactDetails(
@@ -199,8 +199,8 @@ internal class GenerateRequiredOverseasDocumentTemplatePreviewIntegrationTest : 
     }
 }
 
-private fun WebTestClient.RequestBodySpec.withAValidBody(overseasDocumentType: OverseasDocumentType): WebTestClient.RequestBodySpec =
+private fun WebTestClient.RequestBodySpec.withAValidBody(documentCategory: DocumentCategory): WebTestClient.RequestBodySpec =
     body(
-        Mono.just(buildRequiredOverseasDocumentTemplatePreviewRequest(overseasDocumentType = overseasDocumentType)),
+        Mono.just(buildRequiredOverseasDocumentTemplatePreviewRequest(documentCategory = documentCategory)),
         GenerateRejectedOverseasDocumentTemplatePreviewRequest::class.java
     ) as WebTestClient.RequestBodySpec

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/service/TemplateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/service/TemplateServiceTest.kt
@@ -16,17 +16,17 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import uk.gov.dluhc.notificationsapi.client.GovNotifyApiClient
 import uk.gov.dluhc.notificationsapi.client.mapper.NotificationTemplateMapper
+import uk.gov.dluhc.notificationsapi.dto.DocumentCategoryDto
 import uk.gov.dluhc.notificationsapi.dto.LanguageDto
 import uk.gov.dluhc.notificationsapi.dto.NotificationChannel
 import uk.gov.dluhc.notificationsapi.dto.NotificationType
 import uk.gov.dluhc.notificationsapi.dto.NotificationType.ID_DOCUMENT_RESUBMISSION
 import uk.gov.dluhc.notificationsapi.dto.NotificationType.PHOTO_RESUBMISSION
-import uk.gov.dluhc.notificationsapi.dto.OverseasDocumentTypeDto
 import uk.gov.dluhc.notificationsapi.dto.SourceType
 import uk.gov.dluhc.notificationsapi.dto.SourceType.OVERSEAS
 import uk.gov.dluhc.notificationsapi.dto.SourceType.VOTER_CARD
 import uk.gov.dluhc.notificationsapi.dto.api.NotifyTemplatePreviewDto
-import uk.gov.dluhc.notificationsapi.mapper.OverseasDocumentTypeMapper
+import uk.gov.dluhc.notificationsapi.mapper.DocumentCategoryMapper
 import uk.gov.dluhc.notificationsapi.mapper.TemplatePersonalisationDtoMapper
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.buildApplicationRejectedPersonalisationMapFromDto
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.dto.buildApplicationRejectedTemplatePreviewDto
@@ -65,7 +65,7 @@ class TemplateServiceTest {
     private lateinit var templatePersonalisationDtoMapper: TemplatePersonalisationDtoMapper
 
     @Mock
-    private lateinit var overseasDocumentTypeMapper: OverseasDocumentTypeMapper
+    private lateinit var documentCategoryMapper: DocumentCategoryMapper
 
     @Nested
     inner class GeneratePhotoResubmissionTemplatePreview {
@@ -469,7 +469,7 @@ class TemplateServiceTest {
             "IDENTITY, REJECTED_DOCUMENT, 664ed443-f1a6-48d4-b066-b6c0f1e0953a, LETTER, WELSH",
         )
         fun `should return rejected overseas document template preview`(
-            overseasDocumentType: OverseasDocumentTypeDto,
+            documentCategory: DocumentCategoryDto,
             notificationType: NotificationType,
             templateId: String,
             notificationChannel: NotificationChannel,
@@ -480,7 +480,7 @@ class TemplateServiceTest {
                 buildRejectedOverseasDocumentTemplatePreviewDto(
                     language = language,
                     channel = notificationChannel,
-                    overseasDocumentType = overseasDocumentType
+                    documentCategory = documentCategory
                 )
             val personalisationMap = buildRejectedOverseasDocumentPersonalisationMapFromDto(dto.personalisation)
             val previewDto = NotifyTemplatePreviewDto(text = "body", subject = "subject", html = "<p>body</p>")
@@ -490,7 +490,7 @@ class TemplateServiceTest {
             given(templatePersonalisationDtoMapper.toRejectedOverseasDocumentTemplatePersonalisationMap(any()))
                 .willReturn(personalisationMap)
             given(govNotifyApiClient.generateTemplatePreview(any(), any())).willReturn(previewDto)
-            given(overseasDocumentTypeMapper.fromRejectedOverseasDocumentTypeDtoToNotificationTypeDto(any())).willReturn(
+            given(documentCategoryMapper.fromRejectedOverseasDocumentCategoryDtoToNotificationTypeDto(any())).willReturn(
                 notificationType
             )
 
@@ -512,7 +512,7 @@ class TemplateServiceTest {
                 govNotifyApiClient,
                 notificationTemplateMapper,
                 templatePersonalisationDtoMapper,
-                overseasDocumentTypeMapper
+                documentCategoryMapper
             )
         }
     }
@@ -535,7 +535,7 @@ class TemplateServiceTest {
             "IDENTITY, NINO_NOT_MATCHED, abd343c5-edab-4e58-82b4-293736a464d0, LETTER, WELSH",
         )
         fun `should return rejected overseas document template preview`(
-            overseasDocumentType: OverseasDocumentTypeDto,
+            documentCategory: DocumentCategoryDto,
             notificationType: NotificationType,
             templateId: String,
             notificationChannel: NotificationChannel,
@@ -546,7 +546,7 @@ class TemplateServiceTest {
                 buildRequiredOverseasDocumentTemplatePreviewDto(
                     language = language,
                     channel = notificationChannel,
-                    overseasDocumentType = overseasDocumentType
+                    documentCategory = documentCategory
                 )
             val personalisationMap = buildRequiredOverseasDocumentPersonalisationMapFromDto(dto.personalisation)
             val previewDto = NotifyTemplatePreviewDto(text = "body", subject = "subject", html = "<p>body</p>")
@@ -556,7 +556,7 @@ class TemplateServiceTest {
             given(templatePersonalisationDtoMapper.toRequiredOverseasDocumentTemplatePersonalisationMap(any()))
                 .willReturn(personalisationMap)
             given(govNotifyApiClient.generateTemplatePreview(any(), any())).willReturn(previewDto)
-            given(overseasDocumentTypeMapper.fromRequiredOverseasDocumentTypeDtoToNotificationTypeDto(any())).willReturn(
+            given(documentCategoryMapper.fromRequiredOverseasDocumentCategoryDtoToNotificationTypeDto(any())).willReturn(
                 notificationType
             )
 
@@ -578,7 +578,7 @@ class TemplateServiceTest {
                 govNotifyApiClient,
                 notificationTemplateMapper,
                 templatePersonalisationDtoMapper,
-                overseasDocumentTypeMapper
+                documentCategoryMapper
             )
         }
     }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/dto/RejectedOverseasDocumentTemplatePreviewDtoBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/dto/RejectedOverseasDocumentTemplatePreviewDtoBuilder.kt
@@ -1,10 +1,10 @@
 package uk.gov.dluhc.notificationsapi.testsupport.testdata.dto
 
 import uk.gov.dluhc.notificationsapi.dto.ContactDetailsDto
+import uk.gov.dluhc.notificationsapi.dto.DocumentCategoryDto
 import uk.gov.dluhc.notificationsapi.dto.GenerateRejectedOverseasDocumentTemplatePreviewDto
 import uk.gov.dluhc.notificationsapi.dto.LanguageDto
 import uk.gov.dluhc.notificationsapi.dto.NotificationChannel
-import uk.gov.dluhc.notificationsapi.dto.OverseasDocumentTypeDto
 import uk.gov.dluhc.notificationsapi.dto.RejectedOverseasDocumentPersonalisationDto
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.DataFaker
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aValidApplicationReference
@@ -13,11 +13,11 @@ fun buildRejectedOverseasDocumentTemplatePreviewDto(
     channel: NotificationChannel = NotificationChannel.EMAIL,
     language: LanguageDto = LanguageDto.ENGLISH,
     personalisation: RejectedOverseasDocumentPersonalisationDto = buildRejectedOverseasDocumentTemplatePreviewPersonalisation(),
-    overseasDocumentType: OverseasDocumentTypeDto = OverseasDocumentTypeDto.PARENT_GUARDIAN
+    documentCategory: DocumentCategoryDto = DocumentCategoryDto.PARENT_GUARDIAN
 ) = GenerateRejectedOverseasDocumentTemplatePreviewDto(
     channel = channel,
     language = language,
-    overseasDocumentType = overseasDocumentType,
+    documentCategory = documentCategory,
     personalisation = personalisation,
 )
 

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/dto/RequiredOverseasDocumentTemplatePreviewDtoBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/dto/RequiredOverseasDocumentTemplatePreviewDtoBuilder.kt
@@ -1,10 +1,10 @@
 package uk.gov.dluhc.notificationsapi.testsupport.testdata.dto
 
 import uk.gov.dluhc.notificationsapi.dto.ContactDetailsDto
+import uk.gov.dluhc.notificationsapi.dto.DocumentCategoryDto
 import uk.gov.dluhc.notificationsapi.dto.GenerateRequiredOverseasDocumentTemplatePreviewDto
 import uk.gov.dluhc.notificationsapi.dto.LanguageDto
 import uk.gov.dluhc.notificationsapi.dto.NotificationChannel
-import uk.gov.dluhc.notificationsapi.dto.OverseasDocumentTypeDto
 import uk.gov.dluhc.notificationsapi.dto.RequiredOverseasDocumentPersonalisationDto
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.DataFaker
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aValidApplicationReference
@@ -13,11 +13,11 @@ fun buildRequiredOverseasDocumentTemplatePreviewDto(
     channel: NotificationChannel = NotificationChannel.EMAIL,
     language: LanguageDto = LanguageDto.ENGLISH,
     personalisation: RequiredOverseasDocumentPersonalisationDto = buildRequiredOverseasDocumentTemplatePreviewPersonalisation(),
-    overseasDocumentType: OverseasDocumentTypeDto = OverseasDocumentTypeDto.PARENT_GUARDIAN
+    documentCategory: DocumentCategoryDto = DocumentCategoryDto.PARENT_GUARDIAN
 ) = GenerateRequiredOverseasDocumentTemplatePreviewDto(
     channel = channel,
     language = language,
-    overseasDocumentType = overseasDocumentType,
+    documentCategory = documentCategory,
     personalisation = personalisation,
 )
 

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/models/GenerateRejectedOverseasDocumentTemplatePreviewRequestBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/models/GenerateRejectedOverseasDocumentTemplatePreviewRequestBuilder.kt
@@ -1,10 +1,10 @@
 package uk.gov.dluhc.notificationsapi.testsupport.testdata.models
 
 import uk.gov.dluhc.notificationsapi.models.ContactDetails
+import uk.gov.dluhc.notificationsapi.models.DocumentCategory
 import uk.gov.dluhc.notificationsapi.models.GenerateRejectedOverseasDocumentTemplatePreviewRequest
 import uk.gov.dluhc.notificationsapi.models.Language
 import uk.gov.dluhc.notificationsapi.models.NotificationChannel
-import uk.gov.dluhc.notificationsapi.models.OverseasDocumentType
 import uk.gov.dluhc.notificationsapi.models.RejectedDocument
 import uk.gov.dluhc.notificationsapi.models.RejectedOverseasDocumentPersonalisation
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.DataFaker
@@ -15,13 +15,13 @@ import uk.gov.dluhc.notificationsapi.testsupport.testdata.api.buildContactDetail
 fun buildRejectedOverseasDocumentTemplatePreviewRequest(
     personalisation: RejectedOverseasDocumentPersonalisation = buildRejectedOverseasDocumentPersonalisation(),
     language: Language = Language.EN,
-    overseasDocumentType: OverseasDocumentType = OverseasDocumentType.PARENT_MINUS_GUARDIAN,
+    documentCategory: DocumentCategory = DocumentCategory.PARENT_MINUS_GUARDIAN,
     channel: NotificationChannel = NotificationChannel.EMAIL
 ): GenerateRejectedOverseasDocumentTemplatePreviewRequest =
     GenerateRejectedOverseasDocumentTemplatePreviewRequest(
         personalisation = personalisation,
         language = language,
-        overseasDocumentType = overseasDocumentType,
+        documentCategory = documentCategory,
         channel = channel
     )
 

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/models/GenerateRequiredOverseasDocumentTemplatePreviewRequestBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/models/GenerateRequiredOverseasDocumentTemplatePreviewRequestBuilder.kt
@@ -1,10 +1,10 @@
 package uk.gov.dluhc.notificationsapi.testsupport.testdata.models
 
 import uk.gov.dluhc.notificationsapi.models.ContactDetails
+import uk.gov.dluhc.notificationsapi.models.DocumentCategory
 import uk.gov.dluhc.notificationsapi.models.GenerateRequiredOverseasDocumentTemplatePreviewRequest
 import uk.gov.dluhc.notificationsapi.models.Language
 import uk.gov.dluhc.notificationsapi.models.NotificationChannel
-import uk.gov.dluhc.notificationsapi.models.OverseasDocumentType
 import uk.gov.dluhc.notificationsapi.models.RequiredOverseasDocumentPersonalisation
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.DataFaker
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aValidApplicationReference
@@ -14,13 +14,13 @@ import uk.gov.dluhc.notificationsapi.testsupport.testdata.api.buildContactDetail
 fun buildRequiredOverseasDocumentTemplatePreviewRequest(
     personalisation: RequiredOverseasDocumentPersonalisation = buildRequiredOverseasDocumentPersonalisation(),
     language: Language = Language.EN,
-    overseasDocumentType: OverseasDocumentType = OverseasDocumentType.PARENT_MINUS_GUARDIAN,
+    documentCategory: DocumentCategory = DocumentCategory.PARENT_MINUS_GUARDIAN,
     channel: NotificationChannel = NotificationChannel.EMAIL
 ): GenerateRequiredOverseasDocumentTemplatePreviewRequest =
     GenerateRequiredOverseasDocumentTemplatePreviewRequest(
         personalisation = personalisation,
         language = language,
-        overseasDocumentType = overseasDocumentType,
+        documentCategory = documentCategory,
         channel = channel
     )
 


### PR DESCRIPTION
## Description

Renaming all occurrences of `overseasDocumentType` to `documentCategory`. 

Implementing the `documentCategory` in the SQS message templates for the SendNotifyNinoNotMatchedMessage and SendNotifyRejectedDocumentMessage. 
