### PR TITLE
EIP1-9080: EROP OE notification API add sending rejected doc comms

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/SendNotifyMessageMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/SendNotifyMessageMapper.kt
@@ -87,8 +87,8 @@ abstract class SendNotifyMessageMapper {
         message: SendNotifyApplicationRejectedMessage,
     ): SendNotificationRequestDto
 
-    @Mapping(target = "notificationType", source = "messageType")
-    abstract fun fromRejectedDocumentMessageToSendNotificationRequestDto(sendNotifyRejectedDocumentMessage: SendNotifyRejectedDocumentMessage): SendNotificationRequestDto
+    @Mapping(target = "notificationType", expression = "java( rejectedDocumentNotificationType(message) )")
+    abstract fun fromRejectedDocumentMessageToSendNotificationRequestDto(message: SendNotifyRejectedDocumentMessage): SendNotificationRequestDto
 
     @Mapping(
         target = "notificationType",
@@ -127,6 +127,14 @@ abstract class SendNotifyMessageMapper {
                 REJECTED_SIGNATURE_WITH_REASONS
             else
                 REJECTED_SIGNATURE
+        }
+
+    protected fun rejectedDocumentNotificationType(
+        message: SendNotifyRejectedDocumentMessage
+    ): NotificationType =
+        with(message) {
+            val documentCategoryDto = documentCategoryMapper.fromApiMessageToDto(documentCategory)
+            documentCategoryMapper.fromRejectedDocumentCategoryDtoToNotificationTypeDto(documentCategoryDto)
         }
 
     protected fun requiredDocumentNotificationType(

--- a/src/main/resources/openapi/sqs/Notifications-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/Notifications-sqs-messaging.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Notifications SQS Message Types
-  version: '1.13.3'
+  version: '2.0.0'
   description: |-
     Notifications SQS Message Types
     

--- a/src/main/resources/openapi/sqs/Notifications-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/Notifications-sqs-messaging.yaml
@@ -512,6 +512,7 @@ components:
       required:
         - addressLine1
         - country
+        - addressee
     Language:
       title: Language
       description: The language to notify an applicant

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyRejectedDocumentMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyRejectedDocumentMessageListenerIntegrationTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.params.provider.CsvSource
 import uk.gov.dluhc.notificationsapi.config.IntegrationTest
 import uk.gov.dluhc.notificationsapi.database.entity.Channel
 import uk.gov.dluhc.notificationsapi.database.entity.NotificationType
+import uk.gov.dluhc.notificationsapi.messaging.models.DocumentCategory
 import uk.gov.dluhc.notificationsapi.messaging.models.Language
 import uk.gov.dluhc.notificationsapi.messaging.models.NotificationChannel
 import uk.gov.dluhc.notificationsapi.messaging.models.SourceType
@@ -24,16 +25,30 @@ private val logger = KotlinLogging.logger {}
 
 internal class SendNotifyRejectedDocumentMessageListenerIntegrationTest : IntegrationTest() {
 
+    companion object {
+        private const val SOURCE_TYPE_POSTAL = "POSTAL"
+        private const val SOURCE_TYPE_PROXY = "PROXY"
+        private const val SOURCE_TYPE_OVERSEAS = "OVERSEAS"
+        private const val NOTIFICATION_TYPE_IDENTITY = "REJECTED_DOCUMENT"
+        private const val NOTIFICATION_TYPE_PREVIOUS_ADDRESS = "REJECTED_PREVIOUS_ADDRESS"
+        private const val NOTIFICATION_TYPE_PARENT_GUARDIAN = "REJECTED_PARENT_GUARDIAN"
+    }
+
     @ParameterizedTest
     @CsvSource(
         value = [
-            "POSTAL, POSTAL",
-            "PROXY, PROXY",
-        ]
+            "$SOURCE_TYPE_POSTAL, $SOURCE_TYPE_POSTAL, IDENTITY, $NOTIFICATION_TYPE_IDENTITY",
+            "$SOURCE_TYPE_PROXY, $SOURCE_TYPE_PROXY, IDENTITY, $NOTIFICATION_TYPE_IDENTITY",
+            "$SOURCE_TYPE_OVERSEAS, $SOURCE_TYPE_OVERSEAS, IDENTITY, $NOTIFICATION_TYPE_IDENTITY",
+            "$SOURCE_TYPE_OVERSEAS, $SOURCE_TYPE_OVERSEAS, PREVIOUS_MINUS_ADDRESS, $NOTIFICATION_TYPE_PREVIOUS_ADDRESS",
+            "$SOURCE_TYPE_OVERSEAS, $SOURCE_TYPE_OVERSEAS, PARENT_MINUS_GUARDIAN, $NOTIFICATION_TYPE_PARENT_GUARDIAN",
+        ],
     )
     fun `should process Rejected Document message to send Email and save notification`(
         sourceType: SourceType,
-        expectedSourceType: SourceTypeEntity
+        sourceTypeEntity: SourceTypeEntity,
+        documentCategory: DocumentCategory,
+        notificationType: NotificationType
     ) {
         // Given
         val gssCode = aGssCode()
@@ -43,7 +58,8 @@ internal class SendNotifyRejectedDocumentMessageListenerIntegrationTest : Integr
             language = Language.EN,
             gssCode = gssCode,
             sourceType = sourceType,
-            sourceReference = sourceReference
+            sourceReference = sourceReference,
+            documentCategory = documentCategory
         )
         wireMockService.stubNotifySendEmailResponse(NotifySendEmailSuccessResponse())
 
@@ -54,10 +70,14 @@ internal class SendNotifyRejectedDocumentMessageListenerIntegrationTest : Integr
         val stopWatch = StopWatch.createStarted()
         await.atMost(3, TimeUnit.SECONDS).untilAsserted {
             wireMockService.verifyNotifySendEmailCalled()
-            val actualEntity = notificationRepository.getBySourceReferenceAndGssCode(sourceReference, expectedSourceType, listOf(gssCode))
+            val actualEntity = notificationRepository.getBySourceReferenceAndGssCode(
+                sourceReference,
+                sourceTypeEntity,
+                listOf(gssCode)
+            )
             assertThat(actualEntity).hasSize(1).element(0)
                 .extracting("sourceType", "type", "channel")
-                .containsExactlyInAnyOrder(expectedSourceType, NotificationType.REJECTED_DOCUMENT, Channel.EMAIL)
+                .containsExactlyInAnyOrder(sourceTypeEntity, notificationType, Channel.EMAIL)
             stopWatch.stop()
             logger.info("completed assertions in $stopWatch for language EN")
         }
@@ -66,13 +86,18 @@ internal class SendNotifyRejectedDocumentMessageListenerIntegrationTest : Integr
     @ParameterizedTest
     @CsvSource(
         value = [
-            "POSTAL, POSTAL",
-            "PROXY, PROXY"
-        ]
+            "$SOURCE_TYPE_POSTAL, $SOURCE_TYPE_POSTAL, IDENTITY, $NOTIFICATION_TYPE_IDENTITY",
+            "$SOURCE_TYPE_PROXY, $SOURCE_TYPE_PROXY, IDENTITY, $NOTIFICATION_TYPE_IDENTITY",
+            "$SOURCE_TYPE_OVERSEAS, $SOURCE_TYPE_OVERSEAS, IDENTITY, $NOTIFICATION_TYPE_IDENTITY",
+            "$SOURCE_TYPE_OVERSEAS, $SOURCE_TYPE_OVERSEAS, PREVIOUS_MINUS_ADDRESS, $NOTIFICATION_TYPE_PREVIOUS_ADDRESS",
+            "$SOURCE_TYPE_OVERSEAS, $SOURCE_TYPE_OVERSEAS, PARENT_MINUS_GUARDIAN, $NOTIFICATION_TYPE_PARENT_GUARDIAN",
+        ],
     )
     fun `should process Rejected Document message to send Letter and save notification`(
         sourceType: SourceType,
-        expectedSourceType: SourceTypeEntity
+        sourceTypeEntity: SourceTypeEntity,
+        documentCategory: DocumentCategory,
+        notificationType: NotificationType
     ) {
         // Given
         val gssCode = aGssCode()
@@ -82,7 +107,8 @@ internal class SendNotifyRejectedDocumentMessageListenerIntegrationTest : Integr
             language = Language.EN,
             gssCode = gssCode,
             sourceType = sourceType,
-            sourceReference = sourceReference
+            sourceReference = sourceReference,
+            documentCategory = documentCategory
         )
         wireMockService.stubNotifySendLetterResponse(NotifySendLetterSuccessResponse())
 
@@ -93,10 +119,14 @@ internal class SendNotifyRejectedDocumentMessageListenerIntegrationTest : Integr
         val stopWatch = StopWatch.createStarted()
         await.atMost(3, TimeUnit.SECONDS).untilAsserted {
             wireMockService.verifyNotifySendLetterCalled()
-            val actualEntity = notificationRepository.getBySourceReferenceAndGssCode(sourceReference, expectedSourceType, listOf(gssCode))
+            val actualEntity = notificationRepository.getBySourceReferenceAndGssCode(
+                sourceReference,
+                sourceTypeEntity,
+                listOf(gssCode)
+            )
             assertThat(actualEntity).hasSize(1).element(0)
                 .extracting("sourceType", "type", "channel")
-                .containsExactlyInAnyOrder(expectedSourceType, NotificationType.REJECTED_DOCUMENT, Channel.LETTER)
+                .containsExactlyInAnyOrder(sourceTypeEntity, notificationType, Channel.LETTER)
             stopWatch.stop()
             logger.info("completed assertions in $stopWatch for language EN")
         }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/NotificationDestinationDtoMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/mapper/NotificationDestinationDtoMapperTest.kt
@@ -135,4 +135,48 @@ internal class NotificationDestinationDtoMapperTest {
         // Then
         assertThat(destination).isEqualTo(expectedDestination)
     }
+
+    @Test
+    fun `should map SQS MessageAddress to NotificationDestinationDto for Overseas Address with null optional fields`() {
+        // Given
+        val addressee: String = faker.name().firstName()
+        val addressLine1: String = faker.address().streetName()
+        val country: String = faker.address().country()
+
+        val expectedDestination = NotificationDestinationDto(
+            emailAddress = null,
+            postalAddress = null,
+            overseasElectorAddress = OverseasElectorAddress(
+                addressee = addressee,
+                addressLine1 = addressLine1,
+                addressLine2 = null,
+                addressLine3 = null,
+                addressLine4 = null,
+                addressLine5 = null,
+                country = country
+            )
+        )
+
+        val request = MessageAddress(
+            emailAddress = null,
+            overseasElectorAddress = MessageAddressOverseasElectorAddress(
+                address = OverseasElectorAddressMessage(
+                    addressee = addressee,
+                    addressLine1 = addressLine1,
+                    addressLine2 = null,
+                    addressLine3 = null,
+                    addressLine4 = null,
+                    addressLine5 = null,
+                    country = country
+                ),
+            ),
+            postalAddress = null
+        )
+
+        // When
+        val destination = mapper.toNotificationDestinationDto(request)
+
+        // Then
+        assertThat(destination).isEqualTo(expectedDestination)
+    }
 }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/service/SendNotificationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/service/SendNotificationServiceTest.kt
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
@@ -260,11 +259,15 @@ internal class SendNotificationServiceTest {
     }
 
     @ParameterizedTest
-    @CsvSource(
-        value = [
+    @EnumSource(
+        NotificationType::class,
+        names = [
+            "NINO_NOT_MATCHED",
             "PARENT_GUARDIAN_PROOF_REQUIRED",
             "PREVIOUS_ADDRESS_DOCUMENT_REQUIRED",
-            "NINO_NOT_MATCHED"
+            "REJECTED_DOCUMENT",
+            "REJECTED_PARENT_GUARDIAN",
+            "REJECTED_PREVIOUS_ADDRESS"
         ]
     )
     fun `should send letter notification for overseas address`(notificationType: NotificationType) {

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/messaging/models/SendNotifyRejectedDocumentMessageBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/testsupport/testdata/messaging/models/SendNotifyRejectedDocumentMessageBuilder.kt
@@ -1,6 +1,7 @@
 package uk.gov.dluhc.notificationsapi.testsupport.testdata.messaging.models
 
 import uk.gov.dluhc.notificationsapi.messaging.models.ContactDetails
+import uk.gov.dluhc.notificationsapi.messaging.models.DocumentCategory
 import uk.gov.dluhc.notificationsapi.messaging.models.DocumentRejectionReason
 import uk.gov.dluhc.notificationsapi.messaging.models.DocumentRejectionReason.DOCUMENT_MINUS_TOO_MINUS_OLD
 import uk.gov.dluhc.notificationsapi.messaging.models.DocumentRejectionReason.DUPLICATE_MINUS_DOCUMENT
@@ -28,6 +29,7 @@ fun buildSendNotifyRejectedDocumentMessage(
     personalisation: RejectedDocumentPersonalisation = buildRejectedDocumentsPersonalisation(),
     channel: NotificationChannel = NotificationChannel.EMAIL,
     toAddress: MessageAddress = aMessageAddress(),
+    documentCategory: DocumentCategory = DocumentCategory.IDENTITY
 ): SendNotifyRejectedDocumentMessage =
     SendNotifyRejectedDocumentMessage(
         language = language,
@@ -39,6 +41,7 @@ fun buildSendNotifyRejectedDocumentMessage(
         personalisation = personalisation,
         channel = channel,
         toAddress = toAddress,
+        documentCategory = documentCategory
     )
 
 fun buildRejectedDocumentsPersonalisation(


### PR DESCRIPTION
Adding the rejected doc communications for overseas. 

Also fixed a bug that currently exists where the `addressee` is a nullable field and then mapping to a required field causes an error if `addressee` is not present