### PR TITLE
EIP1-9080: Add new document types and tests

### DIFF
--- a/src/main/resources/openapi/sqs/Notifications-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/Notifications-sqs-messaging.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Notifications SQS Message Types
-  version: '2.0.0'
+  version: '2.0.1'
   description: |-
     Notifications SQS Message Types
     
@@ -646,6 +646,19 @@ components:
         - biometric-identity-document
         - ni-electoral-identity-card
         - cd-issued-driving-licence
+        - guardianship-proof
+        - instrument-of-court-appointment
+        - power-of-attorney-letter
+        - letter-from-hmrc
+        - rent-book-from-local-authority
+        - educational-institution-letter
+        - student-loans-company-letter
+        - address-proof-of-title
+        - solicitor-proof-of-purchase-letter
+        - insurance-provider-letter
+        - alternative-proof-of-residency
+        - reference-or-payslip-issued-by-employer
+        - letter-confirming-state-pension
     DocumentRejectionReason:
       title: DocumentRejectionReason
       description: Enum of reasons why a document may be rejected

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/RejectedDocumentsMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/mapper/RejectedDocumentsMapperTest.kt
@@ -164,6 +164,8 @@ class RejectedDocumentsMapperTest {
             ),
             buildRejectedDocumentMessaging(DocumentType.FIREARMS_MINUS_CERTIFICATE, emptyList(), "More notes"),
             buildRejectedDocumentMessaging(DocumentType.ADOPTION_MINUS_CERTIFICATE, emptyList(), null),
+            buildRejectedDocumentMessaging(DocumentType.GUARDIANSHIP_MINUS_PROOF, emptyList(), null),
+            buildRejectedDocumentMessaging(DocumentType.INSURANCE_MINUS_PROVIDER_MINUS_LETTER, emptyList(), "Notes")
         )
         given(
             rejectedDocumentReasonMapper.toDocumentRejectionReasonString(
@@ -207,6 +209,18 @@ class RejectedDocumentsMapperTest {
                 ENGLISH
             )
         ).willReturn("Adoption cert")
+        given(
+            rejectedDocumentTypeMapper.toDocumentTypeString(
+                DocumentType.GUARDIANSHIP_MINUS_PROOF,
+                ENGLISH
+            )
+        ).willReturn("Document proving your connection with your guardian")
+        given(
+            rejectedDocumentTypeMapper.toDocumentTypeString(
+                DocumentType.INSURANCE_MINUS_PROVIDER_MINUS_LETTER,
+                ENGLISH
+            )
+        ).willReturn("Letter from an insurance provider")
 
         // When
         val actual = mapper.mapRejectionDocumentsFromMessaging(ENGLISH, documents)
@@ -224,7 +238,10 @@ class RejectedDocumentsMapperTest {
                     "  * Some notes",
                 "Firearms cert\n" +
                     "  * More notes",
-                "Adoption cert"
+                "Adoption cert",
+                "Document proving your connection with your guardian",
+                "Letter from an insurance provider\n" +
+                    "  * Notes",
             )
         )
 
@@ -241,6 +258,11 @@ class RejectedDocumentsMapperTest {
         verify(rejectedDocumentTypeMapper).toDocumentTypeString(DocumentType.MORTGAGE_MINUS_STATEMENT, ENGLISH)
         verify(rejectedDocumentTypeMapper).toDocumentTypeString(DocumentType.FIREARMS_MINUS_CERTIFICATE, ENGLISH)
         verify(rejectedDocumentTypeMapper).toDocumentTypeString(DocumentType.ADOPTION_MINUS_CERTIFICATE, ENGLISH)
+        verify(rejectedDocumentTypeMapper).toDocumentTypeString(DocumentType.GUARDIANSHIP_MINUS_PROOF, ENGLISH)
+        verify(rejectedDocumentTypeMapper).toDocumentTypeString(
+            DocumentType.INSURANCE_MINUS_PROVIDER_MINUS_LETTER,
+            ENGLISH
+        )
         verifyNoMoreInteractions(rejectedDocumentReasonMapper, rejectedDocumentTypeMapper)
     }
 }


### PR DESCRIPTION
Add new overseas document types to the message templates so we can process these in the message