### PR TITLE
EIP1-8710 Allow configuration of notify URL from infrastructure

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/config/NotifyClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/config/NotifyClientConfiguration.kt
@@ -12,7 +12,10 @@ import uk.gov.service.notify.NotificationClient
 class NotifyClientConfiguration {
 
     @Bean
-    fun notificationClient(@Value("\${api.notify.api-key}") apiKey: String) = NotificationClient(apiKey)
+    fun notificationClient(
+        @Value("\${api.notify.api-key}") apiKey: String,
+        @Value("\${api.notify.base-url}") baseUrl: String,
+    ) = NotificationClient(apiKey, baseUrl)
 
     @Bean
     fun notifyEmailTemplateConfiguration(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,7 @@ dynamodb:
 api:
   notify:
     api-key: ${API_NOTIFY_API_KEY}
+    base-url: ${API_NOTIFY_BASE_URL}
     template:
       voter-card:
         email:

--- a/src/test/resources/application-integration-test.yml
+++ b/src/test/resources/application-integration-test.yml
@@ -14,6 +14,7 @@ dynamodb:
 api:
   notify:
     api-key: developmentintegrationtestkey-137e13d7-6acd-4449-815e-de0eb0c083ba-52408a6d-f230-4c47-9380-128578c3c51a
+    base-url: not-used
     template:
       voter-card:
         email:


### PR DESCRIPTION
This is already setup in infra but was missed from the main service. This allows redirecting on environments for load testing purposes and ensures the IP allowed through the security group is the same as one looked up in infra.