### PR TITLE
EIP1-9735: Ignore wrong API key errors

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -30,8 +30,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          aws-access-key-id: ${{ secrets.DEV_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.DEV2_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.DEV2_AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
 
       - name: Login to Amazon ECR

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          aws-access-key-id: ${{ secrets.DEV_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.DEV2_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.DEV2_AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
 
       - name: Run gradle `check` to lint source code and run tests

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/client/GovNotifyApiClient.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/client/GovNotifyApiClient.kt
@@ -21,7 +21,7 @@ private val logger = KotlinLogging.logger {}
 class GovNotifyApiClient(
     private val notificationClient: NotificationClient,
     private val sendNotificationResponseMapper: SendNotificationResponseMapper,
-    @Value("\${api.notify.catch-wrong-api-key-errors}") private val catchWrongApiKeyErrors: Boolean,
+    @Value("\${api.notify.ignore-wrong-api-key-errors}") private val ignoreWrongApiKeyErrors: Boolean,
 ) {
 
     fun sendEmail(
@@ -37,7 +37,7 @@ class GovNotifyApiClient(
                     sendNotificationResponseMapper.toSendNotificationResponse(this)
                 }
         } catch (ex: NotificationClientException) {
-            if (catchWrongApiKeyErrors && ex.isWrongApiKeyError()) {
+            if (ignoreWrongApiKeyErrors && ex.isWrongApiKeyError()) {
                 logger.info(
                     "This environment's API key does not support sending emails to the specified email address " +
                         "as it is not on the team members list. GOV Notify returned an error, but this notification " +
@@ -65,7 +65,7 @@ class GovNotifyApiClient(
                     sendNotificationResponseMapper.toSendNotificationResponse(this)
                 }
         } catch (ex: NotificationClientException) {
-            if (catchWrongApiKeyErrors && ex.isWrongApiKeyError()) {
+            if (ignoreWrongApiKeyErrors && ex.isWrongApiKeyError()) {
                 logger.info(
                     "This environment's API key does not support sending letters. GOV Notify returned an error, " +
                         "but this notification will be treated as being successfully sent."

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/client/GovNotifyApiClient.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/client/GovNotifyApiClient.kt
@@ -1,6 +1,7 @@
 package uk.gov.dluhc.notificationsapi.client
 
 import mu.KotlinLogging
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import uk.gov.dluhc.notificationsapi.client.mapper.SendNotificationResponseMapper
 import uk.gov.dluhc.notificationsapi.dto.NotificationDestinationDto
@@ -19,7 +20,8 @@ private val logger = KotlinLogging.logger {}
 @Component
 class GovNotifyApiClient(
     private val notificationClient: NotificationClient,
-    private val sendNotificationResponseMapper: SendNotificationResponseMapper
+    private val sendNotificationResponseMapper: SendNotificationResponseMapper,
+    @Value("\${api.notify.catch-wrong-api-key-errors}") private val catchWrongApiKeyErrors: Boolean,
 ) {
 
     fun sendEmail(
@@ -27,7 +29,7 @@ class GovNotifyApiClient(
         emailAddress: String,
         personalisation: Map<String, Any>,
         notificationId: UUID
-    ): SendNotificationResponseDto {
+    ): SendNotificationResponseDto? {
         try {
             logger.info { "Sending email for templateId [$templateId], notificationId [$notificationId]" }
             return notificationClient.sendEmail(templateId, emailAddress, personalisation, notificationId.toString())
@@ -35,6 +37,14 @@ class GovNotifyApiClient(
                     sendNotificationResponseMapper.toSendNotificationResponse(this)
                 }
         } catch (ex: NotificationClientException) {
+            if (catchWrongApiKeyErrors && ex.isWrongApiKeyError()) {
+                logger.info(
+                    "This environment's API key does not support sending emails to the specified email address " +
+                        "as it is not on the team members list. GOV Notify returned an error, but this notification " +
+                        "will be treated as being successfully sent."
+                )
+                return null
+            }
             throw logAndThrowGovNotifyApiException("Send email", ex, templateId)
         }
     }
@@ -45,7 +55,7 @@ class GovNotifyApiClient(
         placeholders: Map<String, Any>,
         notificationId: UUID,
         sourceType: SourceType
-    ): SendNotificationResponseDto {
+    ): SendNotificationResponseDto? {
 
         try {
             logger.info { "Sending letter for templateId [$templateId], notificationId [$notificationId]" }
@@ -55,6 +65,13 @@ class GovNotifyApiClient(
                     sendNotificationResponseMapper.toSendNotificationResponse(this)
                 }
         } catch (ex: NotificationClientException) {
+            if (catchWrongApiKeyErrors && ex.isWrongApiKeyError()) {
+                logger.info(
+                    "This environment's API key does not support sending letters. GOV Notify returned an error, " +
+                        "but this notification will be treated as being successfully sent."
+                )
+                return null
+            }
             throw logAndThrowGovNotifyApiException("Send letter", ex, templateId)
         }
     }
@@ -102,4 +119,7 @@ class GovNotifyApiClient(
             else -> throw GovNotifyApiGeneralException(message)
         }
     }
+
+    fun NotificationClientException.isWrongApiKeyError() =
+        this.httpResult == 400 && this.message == "Can't send to this recipient using a team-only API key"
 }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/database/mapper/NotificationMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/database/mapper/NotificationMapper.kt
@@ -31,7 +31,7 @@ abstract class NotificationMapper {
         notificationId: UUID,
         request: SendNotificationRequestDto,
         personalisation: Map<String, Any>?,
-        sendNotificationResponse: SendNotificationResponseDto,
+        sendNotificationResponse: SendNotificationResponseDto?,
         sentAt: LocalDateTime
     ): Notification
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ api:
   notify:
     api-key: ${API_NOTIFY_API_KEY}
     base-url: ${API_NOTIFY_BASE_URL}
-    catch-wrong-api-key-errors: ${CATCH_WRONG_API_KEY_ERRORS}
+    ignore-wrong-api-key-errors: ${IGNORE_WRONG_API_KEY_ERRORS}
     template:
       voter-card:
         email:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,7 @@ api:
   notify:
     api-key: ${API_NOTIFY_API_KEY}
     base-url: ${API_NOTIFY_BASE_URL}
+    catch-wrong-api-key-errors: ${CATCH_WRONG_API_KEY_ERRORS}
     template:
       voter-card:
         email:

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/client/GovNotifyApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/client/GovNotifyApiClientTest.kt
@@ -52,7 +52,7 @@ internal class GovNotifyApiClientTest {
             govNotifyApiClient = GovNotifyApiClient(
                 notificationClient = notificationClient,
                 sendNotificationResponseMapper = sendNotificationResponseMapper,
-                catchWrongApiKeyErrors = false,
+                ignoreWrongApiKeyErrors = false,
             )
         }
 
@@ -165,7 +165,7 @@ internal class GovNotifyApiClientTest {
             govNotifyApiClient = GovNotifyApiClient(
                 notificationClient = notificationClient,
                 sendNotificationResponseMapper = sendNotificationResponseMapper,
-                catchWrongApiKeyErrors = false,
+                ignoreWrongApiKeyErrors = false,
             )
         }
 
@@ -318,7 +318,7 @@ internal class GovNotifyApiClientTest {
             govNotifyApiClient = GovNotifyApiClient(
                 notificationClient = notificationClient,
                 sendNotificationResponseMapper = sendNotificationResponseMapper,
-                catchWrongApiKeyErrors = true,
+                ignoreWrongApiKeyErrors = true,
             )
         }
 
@@ -389,7 +389,7 @@ internal class GovNotifyApiClientTest {
             govNotifyApiClient = GovNotifyApiClient(
                 notificationClient = notificationClient,
                 sendNotificationResponseMapper = sendNotificationResponseMapper,
-                catchWrongApiKeyErrors = false,
+                ignoreWrongApiKeyErrors = false,
             )
         }
 

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/client/GovNotifyApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/client/GovNotifyApiClientTest.kt
@@ -312,7 +312,7 @@ internal class GovNotifyApiClientTest {
     }
 
     @Nested
-    inner class CatchWrongApiKeyErrors {
+    inner class IgnoreWrongApiKeyErrors {
         @BeforeEach
         fun setupClient() {
             govNotifyApiClient = GovNotifyApiClient(

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/client/GovNotifyApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/client/GovNotifyApiClientTest.kt
@@ -3,13 +3,13 @@ package uk.gov.dluhc.notificationsapi.client
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.EnumSource
-import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
@@ -37,7 +37,6 @@ import uk.gov.service.notify.TemplatePreview
 
 @ExtendWith(MockitoExtension::class)
 internal class GovNotifyApiClientTest {
-    @InjectMocks
     private lateinit var govNotifyApiClient: GovNotifyApiClient
 
     @Mock
@@ -48,6 +47,15 @@ internal class GovNotifyApiClientTest {
 
     @Nested
     inner class SendEmail {
+        @BeforeEach
+        fun setupClient() {
+            govNotifyApiClient = GovNotifyApiClient(
+                notificationClient = notificationClient,
+                sendNotificationResponseMapper = sendNotificationResponseMapper,
+                catchWrongApiKeyErrors = false,
+            )
+        }
+
         @Test
         fun `should send email`() {
             // Given
@@ -104,7 +112,7 @@ internal class GovNotifyApiClientTest {
         }
 
         @Test
-        fun `should throw GovNotifyApiBadRequestException given client throws exception with 400 http result`() {
+        fun `should throw GovNotifyApiBadRequestException given client throws wrong API key error`() {
             // Given
             val emailAddress = anEmailAddress()
             val notificationId = aNotificationId()
@@ -152,6 +160,15 @@ internal class GovNotifyApiClientTest {
 
     @Nested
     inner class SendLetter {
+        @BeforeEach
+        fun setupClient() {
+            govNotifyApiClient = GovNotifyApiClient(
+                notificationClient = notificationClient,
+                sendNotificationResponseMapper = sendNotificationResponseMapper,
+                catchWrongApiKeyErrors = false,
+            )
+        }
+
         @ParameterizedTest
         @EnumSource(value = SourceType::class, names = ["POSTAL", "OVERSEAS"])
         fun `should send letter`(sourceType: SourceType) {
@@ -230,7 +247,7 @@ internal class GovNotifyApiClientTest {
         }
 
         @Test
-        fun `should throw GovNotifyApiBadRequestException given client throws exception with 400 http result`() {
+        fun `should throw GovNotifyApiBadRequestException given client throws wrong API key error`() {
             // Given
             val sourceType = SourceType.POSTAL
             val notificationId = aNotificationId()
@@ -295,7 +312,87 @@ internal class GovNotifyApiClientTest {
     }
 
     @Nested
+    inner class CatchWrongApiKeyErrors {
+        @BeforeEach
+        fun setupClient() {
+            govNotifyApiClient = GovNotifyApiClient(
+                notificationClient = notificationClient,
+                sendNotificationResponseMapper = sendNotificationResponseMapper,
+                catchWrongApiKeyErrors = true,
+            )
+        }
+
+        @Test
+        fun `should return null given client throws wrong API key error when sending email`() {
+            // Given
+            val emailAddress = anEmailAddress()
+            val notificationId = aNotificationId()
+            val personalisation = aNotificationPersonalisationMap()
+            val templateId = aTemplateId().toString()
+            val exceptionMessage = "Can't send to this recipient using a team-only API key"
+            val exception = NotificationClientException(exceptionMessage)
+            setField(exception, "httpResult", 400)
+
+            given(notificationClient.sendEmail(any(), any(), any(), any())).willThrow(exception)
+
+            // When
+            val actual = govNotifyApiClient.sendEmail(templateId, emailAddress, personalisation, notificationId)
+
+            // Then
+            verify(notificationClient).sendEmail(
+                templateId,
+                emailAddress,
+                personalisation,
+                notificationId.toString()
+            )
+            assertThat(actual).isNull()
+        }
+
+        @Test
+        fun `should return null given client throws wrong API key error when sending letter`() {
+            // Given
+            val sourceType = SourceType.POSTAL
+            val postalAddress = aPostalAddress()
+            val notificationId = aNotificationId()
+            val notificationDestination = aNotificationDestination(postalAddress = postalAddress)
+            val personalisation = aNotificationPersonalisationMap()
+            val templateId = aTemplateId().toString()
+            val exceptionMessage = "Can't send to this recipient using a team-only API key"
+            val exception = NotificationClientException(exceptionMessage)
+            setField(exception, "httpResult", 400)
+
+            given(notificationClient.sendLetter(any(), any(), any())).willThrow(exception)
+
+            // When
+            val actual = govNotifyApiClient.sendLetter(
+                templateId,
+                notificationDestination,
+                personalisation,
+                notificationId,
+                sourceType,
+            )
+
+            // Then
+            verify(notificationClient).sendLetter(
+                templateId,
+                (personalisation + postalAddress.toPersonalisationMap()),
+                notificationId.toString()
+            )
+            assertThat(actual).isNull()
+        }
+    }
+
+    @Nested
     inner class GenerateTemplatePreview {
+        @BeforeEach
+        fun setupClient() {
+            govNotifyApiClient = GovNotifyApiClient(
+                notificationClient = notificationClient,
+                sendNotificationResponseMapper = sendNotificationResponseMapper,
+                catchWrongApiKeyErrors = false,
+            )
+        }
+
         @ParameterizedTest
         @CsvSource(
             value = [

--- a/src/test/resources/application-integration-test.yml
+++ b/src/test/resources/application-integration-test.yml
@@ -15,6 +15,7 @@ api:
   notify:
     api-key: developmentintegrationtestkey-137e13d7-6acd-4449-815e-de0eb0c083ba-52408a6d-f230-4c47-9380-128578c3c51a
     base-url: not-used
+    catch-wrong-api-key-errors: false
     template:
       voter-card:
         email:

--- a/src/test/resources/application-integration-test.yml
+++ b/src/test/resources/application-integration-test.yml
@@ -15,7 +15,7 @@ api:
   notify:
     api-key: developmentintegrationtestkey-137e13d7-6acd-4449-815e-de0eb0c083ba-52408a6d-f230-4c47-9380-128578c3c51a
     base-url: not-used
-    catch-wrong-api-key-errors: false
+    ignore-wrong-api-key-errors: false
     template:
       voter-card:
         email:


### PR DESCRIPTION
# Description
- Catch wrong API key errors to prevent guest key environments sending messages to DLQ when attempting to send a letter or send an email to a non-team member address
- Add environment variable to enable / disable catching

# Ticket
https://dluhcdigital.atlassian.net/browse/EIP1-9735