### PR TITLE
EIP1-9735 Fix matching of invalid use of team API key exceptions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,7 +79,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
 
     // UK Government
-    implementation("uk.gov.service.notify:notifications-java-client:3.18.0-RELEASE")
+    implementation("uk.gov.service.notify:notifications-java-client:5.1.0-RELEASE")
 
     // Logging
     runtimeOnly("net.logstash.logback:logstash-logback-encoder:7.3")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/client/GovNotifyApiClient.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/client/GovNotifyApiClient.kt
@@ -121,5 +121,7 @@ class GovNotifyApiClient(
     }
 
     fun NotificationClientException.isWrongApiKeyError() =
-        this.httpResult == 400 && this.message == "Can't send to this recipient using a team-only API key"
+        this.message != null &&
+            (this.httpResult == 400 && this.message!!.contains("send to this recipient using a team-only API key")) ||
+            (this.httpResult == 403 && this.message!!.contains("Cannot send letters with a team api key"))
 }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/client/GovNotifyApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/client/GovNotifyApiClientTest.kt
@@ -329,7 +329,7 @@ internal class GovNotifyApiClientTest {
             val notificationId = aNotificationId()
             val personalisation = aNotificationPersonalisationMap()
             val templateId = aTemplateId().toString()
-            val exceptionMessage = "Can't send to this recipient using a team-only API key"
+            val exceptionMessage = "BadRequestError message: Can`t send to this recipient using a team-only API key"
             val exception = NotificationClientException(exceptionMessage)
             setField(exception, "httpResult", 400)
 
@@ -357,9 +357,9 @@ internal class GovNotifyApiClientTest {
             val notificationDestination = aNotificationDestination(postalAddress = postalAddress)
             val personalisation = aNotificationPersonalisationMap()
             val templateId = aTemplateId().toString()
-            val exceptionMessage = "Can't send to this recipient using a team-only API key"
+            val exceptionMessage = "BadRequest message: Cannot send letters with a team api key"
             val exception = NotificationClientException(exceptionMessage)
-            setField(exception, "httpResult", 400)
+            setField(exception, "httpResult", 403)
 
             given(notificationClient.sendLetter(any(), any(), any())).willThrow(exception)
 


### PR DESCRIPTION
Fix matching of invalid use of team API key exceptions, one message type was missed and the other wasn't picked up as the error contains the text as unparsed JSON rather than clean error string.

Also upgrade Gov Notify client to latest to fix vulnerabilities and gradle as was trying to fix false positives in dependency checking without success but should update gradle at some point anyway. The comparison for the Gov Notify upgrade is [here](https://github.com/alphagov/notifications-java-client/compare/3.18.0-RELEASE...5.1.0-RELEASE) nothing that we use is impacted