### PR TITLE
EIP1-10517: Move get communication endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/database/repository/NotificationRepository.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/database/repository/NotificationRepository.kt
@@ -39,12 +39,12 @@ class NotificationRepository(client: DynamoDbEnhancedClient, tableConfig: Dynamo
 
     /**
      * Returns the Notification identified by its id (primary partition key)
-     * Restricted by ERO and type of application to control access
+     * Restricted by ERO, sourceReference and type of application to control access
      */
-    fun getNotificationById(notificationId: UUID, sourceType: SourceType, gssCodes: List<String>): Notification {
-        val queryRequest = queryRequest(notificationId.toString(), sourceType, gssCodes).build()
+    fun getNotificationById(notificationId: UUID, sourceReference: String, sourceType: SourceType, gssCodes: List<String>): Notification {
+        val queryRequest = queryRequestWithNotificationId(notificationId.toString(), sourceReference, sourceType, gssCodes).build()
 
-        return notificationsTableFull.query(queryRequest).flatMap { it.items() }
+        return notificationsTableFull.index(SOURCE_REFERENCE_INDEX_NAME).query(queryRequest).flatMap { it.items() }
             .getOrElse(0) {
                 throw NotificationNotFoundException(notificationId)
             }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/database/repository/RepositoryUtil.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/database/repository/RepositoryUtil.kt
@@ -20,6 +20,10 @@ fun queryRequestWithoutGssCodes(sourceReference: String, sourceType: SourceType)
         .queryConditional(QueryConditional.keyEqualTo(key(sourceReference)))
         .filterExpression(sourceTypeFilterExpression(sourceType))
 
+fun queryRequestWithNotificationId(notificationId: String, sourceReference: String, sourceType: SourceType, gssCodes: List<String>): QueryEnhancedRequest.Builder =
+    queryRequest(sourceReference, sourceType, gssCodes)
+        .filterExpression(notificationIdFilterExpression(notificationId))
+
 fun sourceTypeFilterExpression(sourceType: SourceType): Expression =
     Expression.builder()
         .expression("#sourceType = :sourceType")
@@ -36,6 +40,13 @@ fun gssCodesFilterExpression(gssCodes: List<String>): Expression =
                 filterExpression.putExpressionValue(":gssCode_$index", AttributeValue.fromS(gssCode))
             }
         }.build()
+
+fun notificationIdFilterExpression(notificationId: String): Expression =
+    Expression.builder()
+        .expression("#id = :notificationId")
+        .putExpressionName("#id", "id")
+        .putExpressionValue(":notificationId", AttributeValue.fromS(notificationId))
+        .build()
 
 fun key(partitionValue: String): Key =
     Key.builder().partitionValue(partitionValue).build()

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/rest/SentCommunicationsController.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/rest/SentCommunicationsController.kt
@@ -47,10 +47,11 @@ class SentCommunicationsController(
             CommunicationsHistoryResponse(communications = it)
         }
 
-    @GetMapping("{communicationId}")
+    @GetMapping("applications/{applicationId}/{communicationId}")
     @PreAuthorize(HAS_APPLICATION_SPECIFIC_ERO_ADMIN_AUTHORITY)
     fun getSentCommunication(
         @PathVariable eroId: String,
+        @PathVariable applicationId: String,
         @PathVariable communicationId: String,
         @RequestParam(required = true) sourceType: SourceTypeApi,
     ): SentCommunicationResponse {
@@ -58,6 +59,7 @@ class SentCommunicationsController(
             return sentNotificationsService.getNotificationByIdEroAndType(
                 notificationId = UUID.fromString(communicationId),
                 eroId = eroId,
+                sourceReference = applicationId,
                 sourceType = sourceTypeMapper.fromApiToDto(sourceType),
             ).let {
                 notificationApiMapper.toSentCommunicationsApi(it)

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/service/SentNotificationsService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/service/SentNotificationsService.kt
@@ -66,11 +66,13 @@ class SentNotificationsService(
     fun getNotificationByIdEroAndType(
         notificationId: UUID,
         eroId: String,
+        sourceReference: String,
         sourceType: SourceType,
     ): Notification =
         eroService.lookupGssCodesForEro(eroId).let { gssCodes ->
             notificationRepository.getNotificationById(
                 notificationId = notificationId,
+                sourceReference = sourceReference,
                 sourceType = sourceTypeMapper.fromDtoToEntity(sourceType),
                 gssCodes = gssCodes,
             )

--- a/src/main/resources/openapi/NotificationsAPIs.yaml
+++ b/src/main/resources/openapi/NotificationsAPIs.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Notifications APIs
-  version: '1.17.2'
+  version: '1.18.0'
   description: Notifications APIs
 #
 # --------------------------------------------------------------------------------
@@ -104,10 +104,16 @@ paths:
   #
   # Get the subject and body of a specified notification
   # --------------------------------------------------------------------------------
-  '/eros/{eroId}/communications/{communicationId}':
+  '/eros/{eroId}/communications/applications/{applicationId}/{communicationId}':
     parameters:
       - name: eroId
         description: The ID of the Electoral Registration Office responsible for the application.
+        schema:
+          type: string
+        in: path
+        required: true
+      - name: applicationId
+        description: The identifier of the application to retrieve the communications history.
         schema:
           type: string
         in: path

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GetCommunicationByIdIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GetCommunicationByIdIntegrationTest.kt
@@ -1,0 +1,129 @@
+package uk.gov.dluhc.notificationsapi.rest
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import uk.gov.dluhc.notificationsapi.config.IntegrationTest
+import uk.gov.dluhc.notificationsapi.database.entity.Channel
+import uk.gov.dluhc.notificationsapi.database.entity.NotificationType
+import uk.gov.dluhc.notificationsapi.database.entity.SourceType
+import uk.gov.dluhc.notificationsapi.models.SentCommunicationResponse
+import uk.gov.dluhc.notificationsapi.rest.GetCommunicationHistoryByApplicationIdIntegrationTest.Companion
+import uk.gov.dluhc.notificationsapi.testsupport.bearerToken
+import uk.gov.dluhc.notificationsapi.testsupport.getDifferentRandomEroId
+import uk.gov.dluhc.notificationsapi.testsupport.getRandomEroId
+import uk.gov.dluhc.notificationsapi.testsupport.model.buildElectoralRegistrationOfficeResponse
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.UNAUTHORIZED_BEARER_TOKEN
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.aRandomNotificationId
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.aRandomSourceReference
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.aRequestor
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.database.entity.aNotificationBuilder
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.database.entity.aNotifyDetails
+import uk.gov.dluhc.notificationsapi.testsupport.testdata.getBearerToken
+import java.time.LocalDateTime
+import java.util.*
+
+internal class GetCommunicationByIdIntegrationTest: IntegrationTest() {
+
+    companion object {
+        private val ERO_ID = getRandomEroId()
+        private val OTHER_ERO_ID = getDifferentRandomEroId(ERO_ID)
+    }
+
+    @Test
+    fun `should return unauthorized given no bearer token`() {
+        webTestClient.get()
+            .uri(buildUri())
+            .exchange()
+            .expectStatus()
+            .isUnauthorized
+    }
+
+    @Test
+    fun `should return unauthorized given user with invalid bearer token`() {
+        webTestClient.get()
+            .uri(buildUri())
+            .bearerToken(UNAUTHORIZED_BEARER_TOKEN)
+            .contentType(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isUnauthorized
+    }
+
+    @Test
+    fun `should return forbidden given user with valid bearer token belonging to a different group`() {
+        wireMockService.stubCognitoJwtIssuerResponse()
+        val eroId = ERO_ID
+
+        webTestClient.get()
+            .uri(buildUri(eroId = eroId))
+            .bearerToken(getBearerToken(eroId = eroId, groups = listOf("ero-$eroId", "ero-admin-$eroId")))
+            .contentType(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isForbidden
+    }
+
+    @Test
+    fun `should return forbidden given user with valid bearer token belonging to a different ero`() {
+        wireMockService.stubCognitoJwtIssuerResponse()
+        val requestEroId = ERO_ID
+        val userGroupEroId = OTHER_ERO_ID
+
+        webTestClient.get()
+            .uri(buildUri(eroId = requestEroId))
+            .bearerToken(getBearerToken(eroId = userGroupEroId, groups = listOf("ero-$userGroupEroId", "ero-vc-admin-$userGroupEroId")))
+            .contentType(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isForbidden
+    }
+
+    @Test
+    fun `should return subject and body of a sent communication when given valid application id and communication id`() {
+        // Given
+        wireMockService.stubCognitoJwtIssuerResponse()
+        val eroResponse = buildElectoralRegistrationOfficeResponse(id = ERO_ID)
+        wireMockService.stubEroManagementGetEroByEroId(eroResponse, ERO_ID)
+
+        val applicationId = aRandomSourceReference()
+        val notificationId = aRandomNotificationId()
+        val sourceType = SourceType.POSTAL
+        val authGroupPrefix = "ero-postal-admin"
+        val requestor = aRequestor()
+
+        val sentNotification = aNotificationBuilder(
+            id = notificationId,
+            sourceReference = applicationId,
+            sourceType = sourceType,
+            gssCode = eroResponse.localAuthorities[0].gssCode,
+            requestor = requestor,
+            channel = Channel.EMAIL,
+            type = NotificationType.PHOTO_RESUBMISSION,
+            notifyDetails = aNotifyDetails(),
+            sentAt = LocalDateTime.of(2022, 10, 6, 9, 58, 24),
+        )
+
+        notificationRepository.saveNotification(sentNotification)
+
+        val expected = SentCommunicationResponse(
+            subject = sentNotification.notifyDetails!!.subject!!,
+            body = sentNotification.notifyDetails!!.body!!,
+        )
+
+        // When
+        val response = webTestClient.get()
+            .uri(buildUri(eroId = ERO_ID, applicationId = applicationId, notificationId = notificationId.toString(), sourceType = sourceType.toString()))
+            .bearerToken(getBearerToken(eroId = ERO_ID, groups = listOf("ero-${ERO_ID}", "$authGroupPrefix-${ERO_ID}")))
+            .contentType(MediaType.APPLICATION_JSON)
+            .exchange()
+
+        // Then
+        response.expectStatus().isOk
+        val actual = response.returnResult(SentCommunicationResponse::class.java).responseBody.blockFirst()
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    private fun buildUri(eroId: String = ERO_ID, applicationId: String = UUID.randomUUID().toString(), notificationId: String = UUID.randomUUID().toString(), sourceType: String = SourceType.POSTAL.toString()) =
+        "/eros/$eroId/communications/applications/$applicationId/$notificationId?sourceType=$sourceType"
+}

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GetCommunicationByIdIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/rest/GetCommunicationByIdIntegrationTest.kt
@@ -8,7 +8,6 @@ import uk.gov.dluhc.notificationsapi.database.entity.Channel
 import uk.gov.dluhc.notificationsapi.database.entity.NotificationType
 import uk.gov.dluhc.notificationsapi.database.entity.SourceType
 import uk.gov.dluhc.notificationsapi.models.SentCommunicationResponse
-import uk.gov.dluhc.notificationsapi.rest.GetCommunicationHistoryByApplicationIdIntegrationTest.Companion
 import uk.gov.dluhc.notificationsapi.testsupport.bearerToken
 import uk.gov.dluhc.notificationsapi.testsupport.getDifferentRandomEroId
 import uk.gov.dluhc.notificationsapi.testsupport.getRandomEroId
@@ -23,7 +22,7 @@ import uk.gov.dluhc.notificationsapi.testsupport.testdata.getBearerToken
 import java.time.LocalDateTime
 import java.util.*
 
-internal class GetCommunicationByIdIntegrationTest: IntegrationTest() {
+internal class GetCommunicationByIdIntegrationTest : IntegrationTest() {
 
     companion object {
         private val ERO_ID = getRandomEroId()
@@ -114,7 +113,7 @@ internal class GetCommunicationByIdIntegrationTest: IntegrationTest() {
         // When
         val response = webTestClient.get()
             .uri(buildUri(eroId = ERO_ID, applicationId = applicationId, notificationId = notificationId.toString(), sourceType = sourceType.toString()))
-            .bearerToken(getBearerToken(eroId = ERO_ID, groups = listOf("ero-${ERO_ID}", "$authGroupPrefix-${ERO_ID}")))
+            .bearerToken(getBearerToken(eroId = ERO_ID, groups = listOf("ero-$ERO_ID", "$authGroupPrefix-$ERO_ID")))
             .contentType(MediaType.APPLICATION_JSON)
             .exchange()
 
@@ -168,7 +167,7 @@ internal class GetCommunicationByIdIntegrationTest: IntegrationTest() {
         // When, Then
         webTestClient.get()
             .uri(buildUri(eroId = ERO_ID, applicationId = anotherApplicationId, notificationId = notificationId.toString(), sourceType = sourceType.toString()))
-            .bearerToken(getBearerToken(eroId = ERO_ID, groups = listOf("ero-${ERO_ID}", "$authGroupPrefix-${ERO_ID}")))
+            .bearerToken(getBearerToken(eroId = ERO_ID, groups = listOf("ero-$ERO_ID", "$authGroupPrefix-$ERO_ID")))
             .contentType(MediaType.APPLICATION_JSON)
             .exchange()
             .expectStatus()

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/service/SentNotificationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/service/SentNotificationsServiceTest.kt
@@ -103,6 +103,7 @@ class SentNotificationsServiceTest {
         val notificationId = aRandomNotificationId()
         val eroId = aValidKnownEroId()
         val sourceType = aSourceType()
+        val sourceReference = aSourceReference()
 
         val gssCodes = listOf(aGssCode(), anotherGssCode())
         given(eroService.lookupGssCodesForEro(any())).willReturn(gssCodes)
@@ -113,7 +114,7 @@ class SentNotificationsServiceTest {
             gssCode = gssCodes[0],
             requestor = "vc-admin-1@some-ero.gov.uk",
         )
-        given(notificationRepository.getNotificationById(any(), any(), any())).willReturn(
+        given(notificationRepository.getNotificationById(any(), any(), any(), any())).willReturn(
             notificationEntity,
         )
 
@@ -124,7 +125,7 @@ class SentNotificationsServiceTest {
         )
 
         // When
-        val actual = service.getNotificationByIdEroAndType(notificationId, eroId, sourceType)
+        val actual = service.getNotificationByIdEroAndType(notificationId, eroId, sourceReference, sourceType)
 
         // Then
         assertThat(actual).isEqualTo(notification)


### PR DESCRIPTION
## Describe your changes
Moves the get communication endpoint to
```
GET {{notifications-api}}/eros/:eroId/communications/applications/:applicationId/:communicationId
```
This adds the `applicationId` to the request which we use to restrict access to communciations.

## Issue ticket number and link

https://dluhcdigital.atlassian.net/browse/EIP1-10517

## Checklist before requesting a review

- [x] I double checked that ACs on the ticket are met by this code update
- [ ] I have added testing steps to the ticket
- [x] I have updated the relevant yml versions
- [x] I have formatted the code
- [x] I have added tests to new code and updated existing tests where needed
- [ ] I have added any corresponding changes to the API services

## Additional notes
