### PR TITLE
EIP1-11191: trigger stats update for application

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -169,6 +169,12 @@ tasks.create("generate-models-from-openapi-document-NotificationsAPIs.yaml", Gen
     configOptions.put("documentationProvider", "none")
 }
 
+tasks.create("generate-models-from-openapi-document-UpdateStatisticsMessage.yaml", GenerateTask::class) {
+    enabled = true
+    inputSpec.set("$projectDir/src/main/resources/openapi/sqs/applications-api/UpdateStatisticsMessage.yaml")
+    packageName.set("uk.gov.dluhc.applicationsapi.messaging")
+}
+
 tasks.create("generate-models-from-openapi-document-Notifications-sqs-message-types.yaml", GenerateTask::class) {
     enabled = true
     inputSpec.set("$projectDir/src/main/resources/openapi/sqs/Notifications-sqs-messaging.yaml")

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/config/MessagingConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/config/MessagingConfiguration.kt
@@ -11,6 +11,7 @@ import org.springframework.context.annotation.Profile
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import uk.gov.dluhc.messagingsupport.MessageQueue
 import uk.gov.dluhc.messagingsupport.MessagingConfigurationHelper
+import uk.gov.dluhc.applicationsapi.messaging.models.UpdateStatisticsMessage as ApplicationUpdateStatisticsMessage
 import uk.gov.dluhc.overseasapplicationsapi.messaging.models.UpdateStatisticsMessage as OverseasUpdateStatisticsMessage
 import uk.gov.dluhc.postalapplicationsapi.messaging.models.UpdateStatisticsMessage as PostalUpdateStatisticsMessage
 import uk.gov.dluhc.proxyapplicationsapi.messaging.models.UpdateStatisticsMessage as ProxyUpdateStatisticsMessage
@@ -32,7 +33,7 @@ class MessagingConfiguration {
     private lateinit var triggerOverseasApplicationStatisticsUpdateQueueName: String
 
     @Value("\${sqs.trigger-application-statistics-update-queue-name}")
-    private  lateinit var triggerApplicationStatisticsUpdateQueueName: String
+    private lateinit var triggerApplicationStatisticsUpdateQueueName: String
 
     @Bean
     @Primary

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/config/MessagingConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/config/MessagingConfiguration.kt
@@ -31,6 +31,9 @@ class MessagingConfiguration {
     @Value("\${sqs.trigger-overseas-application-statistics-update-queue-name}")
     private lateinit var triggerOverseasApplicationStatisticsUpdateQueueName: String
 
+    @Value("\${sqs.trigger-application-statistics-update-queue-name}")
+    private  lateinit var triggerApplicationStatisticsUpdateQueueName: String
+
     @Bean
     @Primary
     @Profile("!integration-test")
@@ -54,6 +57,10 @@ class MessagingConfiguration {
     @Bean
     fun triggerOverseasApplicationStatisticsUpdateQueue(sqsTemplate: SqsTemplate) =
         MessageQueue<OverseasUpdateStatisticsMessage>(triggerOverseasApplicationStatisticsUpdateQueueName, sqsTemplate)
+
+    @Bean
+    fun triggerApplicationStatisticsUpdateQueue(sqsTemplate: SqsTemplate) =
+        MessageQueue<ApplicationUpdateStatisticsMessage>(triggerApplicationStatisticsUpdateQueueName, sqsTemplate)
 
     @Bean
     fun sqsMessagingMessageConverter(

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/dto/SendNotificationRequestDto.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/dto/SendNotificationRequestDto.kt
@@ -9,4 +9,5 @@ data class SendNotificationRequestDto(
     val sourceReference: String,
     val toAddress: NotificationDestinationDto,
     val notificationType: NotificationType,
+    val isFromApplicationApi: Boolean = false,
 )

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/service/SendNotificationService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/service/SendNotificationService.kt
@@ -43,7 +43,7 @@ class SendNotificationService(
             val sentNotification = sendNotificationForChannel(requestDto, personalisationMap, notificationId, sentAt)
             saveSentMessageAndCreateAuditOrLogError(sentNotification)
             if (shouldSendApplicationStatisticsUpdate(requestDto)) {
-                statisticsUpdateService.triggerStatisticsUpdate(requestDto.sourceReference, requestDto.sourceType)
+                statisticsUpdateService.triggerStatisticsUpdate(requestDto.sourceReference, requestDto.sourceType, requestDto.isFromApplicationApi)
             }
         } catch (ex: GovNotifyNonRetryableException) {
             logger.warn("Non-retryable error returned from the Notify service: ${ex.message}")

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/service/StatisticsUpdateService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/service/StatisticsUpdateService.kt
@@ -3,6 +3,7 @@ package uk.gov.dluhc.notificationsapi.service
 import org.springframework.stereotype.Service
 import uk.gov.dluhc.messagingsupport.MessageQueue
 import uk.gov.dluhc.notificationsapi.dto.SourceType
+import uk.gov.dluhc.notificationsapi.exception.InvalidSourceTypeException
 import java.util.UUID
 import uk.gov.dluhc.applicationsapi.messaging.models.UpdateStatisticsMessage as ApplicationUpdateStatisticsMessage
 import uk.gov.dluhc.overseasapplicationsapi.messaging.models.UpdateStatisticsMessage as OverseasUpdateStatisticsMessage
@@ -29,7 +30,9 @@ class StatisticsUpdateService(
                 SourceType.POSTAL -> submitToTriggerPostalApplicationStatisticsUpdateQueue(applicationId, deduplicationId)
                 SourceType.PROXY -> submitToTriggerProxyApplicationStatisticsUpdateQueue(applicationId, deduplicationId)
                 SourceType.OVERSEAS -> submitToTriggerOverseasStatisticsUpdateQueue(applicationId, deduplicationId)
-                else -> {}
+                else -> {
+                    throw InvalidSourceTypeException(sourceType.toString())
+                }
             }
         }
     }

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/service/StatisticsUpdateService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/service/StatisticsUpdateService.kt
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service
 import uk.gov.dluhc.messagingsupport.MessageQueue
 import uk.gov.dluhc.notificationsapi.dto.SourceType
 import java.util.UUID
+import uk.gov.dluhc.applicationsapi.messaging.models.UpdateStatisticsMessage as ApplicationUpdateStatisticsMessage
 import uk.gov.dluhc.overseasapplicationsapi.messaging.models.UpdateStatisticsMessage as OverseasUpdateStatisticsMessage
 import uk.gov.dluhc.postalapplicationsapi.messaging.models.UpdateStatisticsMessage as PostalUpdateStatisticsMessage
 import uk.gov.dluhc.proxyapplicationsapi.messaging.models.UpdateStatisticsMessage as ProxyUpdateStatisticsMessage

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -185,6 +185,7 @@ sqs:
   trigger-postal-application-statistics-update-queue-name: ${SQS_TRIGGER_POSTAL_APPLICATION_STATISTICS_UPDATE_QUEUE_NAME}
   trigger-proxy-application-statistics-update-queue-name: ${SQS_TRIGGER_PROXY_APPLICATION_STATISTICS_UPDATE_QUEUE_NAME}
   trigger-overseas-application-statistics-update-queue-name: ${SQS_TRIGGER_OVERSEAS_APPLICATION_STATISTICS_UPDATE_QUEUE_NAME}
+  trigger-application-statistics-update-queue-name: ${SQS_TRIGGER_APPLICATION_STATISTICS_UPDATE_QUEUE_NAME}
 
 logging:
   pattern:

--- a/src/main/resources/openapi/sqs/Notifications-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/Notifications-sqs-messaging.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Notifications SQS Message Types
-  version: '2.0.7'
+  version: '2.0.8'
   description: |-
     Notifications SQS Message Types
     
@@ -178,6 +178,9 @@ components:
           $ref: '#/components/schemas/MessageAddress'
         messageType:
           $ref: '#/components/schemas/MessageType'
+        isFromApplicationApi:
+          type: boolean
+          description: Determines whether the application should be processed by the OS applications queue or by the old queues
       required:
         - language
         - sourceType

--- a/src/main/resources/openapi/sqs/applications-api/UpdateStatisticsMessage.yaml
+++ b/src/main/resources/openapi/sqs/applications-api/UpdateStatisticsMessage.yaml
@@ -1,0 +1,60 @@
+openapi: 3.0.0
+info:
+  title: Application API SQS Message Types for EROP Clients
+  version: '1.0.0'
+  description: |-
+    Application API SQS Message Types for EROP Clients
+    
+    Messages defined in this spec are produced by EROP (VCA and other apps) and consumed by VCA
+    
+    Whilst this is an openAPI spec, it does not imply being used to define REST APIs, nor is it intended to.
+    
+    The `paths` elements are being used to document (at a high level) the SQS queues and the request bodies that are expected
+    to be published to them. **There is no intent to generate or implement SQS queues or listener classes from this document.**
+    
+    The `paths` element is only being used in order to maintain the structure of the openApi spec, as `paths` are required 
+    elements.
+#
+# --------------------------------------------------------------------------------
+#
+
+paths:
+  #
+  # --------------------------------------------------------------------------------
+  # SQS Queues start here
+  # --------------------------------------------------------------------------------
+  #
+  '/trigger-application-statistics-update':
+    post:
+      tags:
+        - SQS Queues
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateStatisticsMessage'
+      responses:
+        '204':
+          description: No response content.
+components:
+#
+# Schema and Enum Definitions
+# --------------------------------------------------------------------------------
+  schemas:
+    UpdateStatisticsMessage:
+      title: UpdateStatisticsMessage
+      type: object
+      description: SQS Message for initiating a statistics update for a postal application.
+      properties:
+        applicationId:
+          type: string
+          description: The identifier of the application
+          example: 1f0f76a9a66f438b9bb33070
+      required:
+        - postalApplicationId
+  requestBodies:
+    #
+    # Request Body Definitions
+    # --------------------------------------------------------------------------------
+    UpdateStatisticsMessage:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/UpdateStatisticsMessage'

--- a/src/main/resources/openapi/sqs/applications-api/UpdateStatisticsMessage.yaml
+++ b/src/main/resources/openapi/sqs/applications-api/UpdateStatisticsMessage.yaml
@@ -5,7 +5,7 @@ info:
   description: |-
     Application API SQS Message Types for EROP Clients
     
-    Messages defined in this spec are produced by EROP (VCA and other apps) and consumed by VCA
+    Messages defined in this spec are produced by EROP and consumed by the applications API
     
     Whilst this is an openAPI spec, it does not imply being used to define REST APIs, nor is it intended to.
     
@@ -34,21 +34,21 @@ paths:
         '204':
           description: No response content.
 components:
-#
-# Schema and Enum Definitions
-# --------------------------------------------------------------------------------
+  #
+  # Schema and Enum Definitions
+  # --------------------------------------------------------------------------------
   schemas:
     UpdateStatisticsMessage:
       title: UpdateStatisticsMessage
       type: object
-      description: SQS Message for initiating a statistics update for a postal application.
+      description: SQS Message for initiating a statistics update for an application.
       properties:
         applicationId:
           type: string
           description: The identifier of the application
           example: 1f0f76a9a66f438b9bb33070
       required:
-        - postalApplicationId
+        - applicationId
   requestBodies:
     #
     # Request Body Definitions

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/service/SendNotificationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/service/SendNotificationServiceTest.kt
@@ -431,7 +431,7 @@ internal class SendNotificationServiceTest {
         sendNotificationService.sendNotification(request, personalisation)
 
         // Then
-        verify(statisticsUpdateService).triggerStatisticsUpdate(notification.sourceReference!!, SourceType.VOTER_CARD)
+        verify(statisticsUpdateService).triggerStatisticsUpdate(notification.sourceReference!!, SourceType.VOTER_CARD, request.isFromApplicationApi)
     }
 
     @ParameterizedTest
@@ -495,7 +495,7 @@ internal class SendNotificationServiceTest {
         sendNotificationService.sendNotification(request, personalisation)
 
         // Then
-        verify(statisticsUpdateService).triggerStatisticsUpdate(notification.sourceReference!!, SourceType.POSTAL)
+        verify(statisticsUpdateService).triggerStatisticsUpdate(notification.sourceReference!!, SourceType.POSTAL, request.isFromApplicationApi)
     }
 
     @ParameterizedTest
@@ -559,7 +559,7 @@ internal class SendNotificationServiceTest {
         sendNotificationService.sendNotification(request, personalisation)
 
         // Then
-        verify(statisticsUpdateService).triggerStatisticsUpdate(notification.sourceReference!!, sourceType)
+        verify(statisticsUpdateService).triggerStatisticsUpdate(notification.sourceReference!!, sourceType, request.isFromApplicationApi)
     }
 
     @ParameterizedTest

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/service/StatisticsUpdateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/service/StatisticsUpdateServiceTest.kt
@@ -12,12 +12,14 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.capture
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
 import uk.gov.dluhc.messagingsupport.MessageQueue
 import uk.gov.dluhc.notificationsapi.dto.SourceType
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aRandomSourceReference
+import uk.gov.dluhc.applicationsapi.messaging.models.UpdateStatisticsMessage as ApplicationUpdateStatisticsMessage
 import uk.gov.dluhc.overseasapplicationsapi.messaging.models.UpdateStatisticsMessage as OverseasUpdateStatisticsMessage
 import uk.gov.dluhc.postalapplicationsapi.messaging.models.UpdateStatisticsMessage as PostalUpdateStatisticsMessage
 import uk.gov.dluhc.proxyapplicationsapi.messaging.models.UpdateStatisticsMessage as ProxyUpdateStatisticsMessage
@@ -190,7 +192,7 @@ class StatisticsUpdateServiceTest {
         statisticsUpdateService.triggerStatisticsUpdate(applicationId, SourceType.OVERSEAS, true)
 
         // Then
-        verify(triggerApplicationStatisticsUpdateQueue).submit(
+        verify(triggerApplicationStatisticsUpdateQueue, times(4)).submit(
             eq(ApplicationUpdateStatisticsMessage(applicationId)),
             any(),
         )

--- a/src/test/resources/application-integration-test.yml
+++ b/src/test/resources/application-integration-test.yml
@@ -177,3 +177,4 @@ sqs:
   trigger-postal-application-statistics-update-queue-name: test-trigger-postal-application-statistics-update.fifo
   trigger-proxy-application-statistics-update-queue-name: test-trigger-proxy-application-statistics-update.fifo
   trigger-overseas-application-statistics-update-queue-name: test-trigger-overseas-application-statistics-update.fifo
+  trigger-application-statistics-update-queue-name: test-trigger-application-statistics-update.fifo


### PR DESCRIPTION
## Describe your changes
Adds an optional parameter to notifications queue SQS message types that flags if an application was processed through the new applications api or old set of APIs. Sends stats updates to the new stats queue. 

## Issue ticket number and link

https://dluhcdigital.atlassian.net/browse/EIP1-11191

## Checklist before requesting a review

- [ ] I double checked that ACs on the ticket are met by this code update
- [ ] I have added testing steps to the ticket
- [ ] I have updated the relevant yml versions
- [ ] I have formatted the code
- [ ] I have added tests to new code and updated existing tests where needed
- [ ] I have added any corresponding changes to the API services

## Additional notes
