### PR TITLE
EROPSPT-403: Bump dependencycheck to 12

### DIFF
--- a/.github/workflows/owasp-dependency-check.yml
+++ b/.github/workflows/owasp-dependency-check.yml
@@ -20,7 +20,7 @@ jobs:
           java-version: 17
           cache: gradle
       - name: Run gradle OWASP Dependency Analyzer
-        run: ./gradlew clean dependencyCheckAnalyze --no-daemon 2>error.log
+        run: ./gradlew clean dependencyCheckAnalyze -Dnvd.api.key=${{ secrets.VULNERABILITY_ALERTS_NVD_API_KEY }} --no-daemon 2>error.log
         continue-on-error: true
       - name: Extract CVEs
         run: |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint") version "11.3.1"
     id("org.jlleitschuh.gradle.ktlint-idea") version "11.3.1"
     id("org.openapi.generator") version "7.0.1"
-    id("org.owasp.dependencycheck") version "8.2.1"
+    id("org.owasp.dependencycheck") version "12.0.1"
 }
 
 group = "uk.gov.dluhc"


### PR DESCRIPTION
## Describe your changes

A bug (https://github.com/jeremylong/DependencyCheck/issues/5991) in the old version of dependencycheck reports false positives with the json package so I've upgraded it to the latest version and also made sure the OWASP job uses our NVD API key (as with other repos).

## Issue ticket number and link

https://dluhcdigital.atlassian.net/browse/EIP1-

## Checklist before requesting a review

- [ ] I double checked that ACs on the ticket are met by this code update
- [ ] I have added testing steps to the ticket
- [ ] I have updated the relevant yml versions
- [ ] I have formatted the code
- [ ] I have added tests to new code and updated existing tests where needed
- [ ] I have added any corresponding changes to the API services

## Additional notes
