### PR TITLE
EROPSPT-403: Downgrade dependencycheck to 10 due to spring boot build…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint") version "11.3.1"
     id("org.jlleitschuh.gradle.ktlint-idea") version "11.3.1"
     id("org.openapi.generator") version "7.0.1"
-    id("org.owasp.dependencycheck") version "12.0.1"
+    id("org.owasp.dependencycheck") version "10.0.4"
 }
 
 group = "uk.gov.dluhc"


### PR DESCRIPTION
… issues

## Describe your changes

I had issues building dependencycheck 12 so downgrading to version 10 instead. [Stephen pointed out that they previously also had issues with certain versions of the plugin](https://softwire.slack.com/archives/C05KAM40NUU/p1737381419757419?thread_ts=1737375700.691019&cid=C05KAM40NUU).

https://github.com/spring-projects/spring-boot/issues/42952#issuecomment-2506304372

## Issue ticket number and link

https://dluhcdigital.atlassian.net/browse/EIP1-

## Checklist before requesting a review

- [ ] I double checked that ACs on the ticket are met by this code update
- [ ] I have added testing steps to the ticket
- [ ] I have updated the relevant yml versions
- [ ] I have formatted the code
- [ ] I have added tests to new code and updated existing tests where needed
- [ ] I have added any corresponding changes to the API services

## Additional notes
