### PR TITLE
EROPSPT-NONE: Remove localstack pro api key instruction from README and actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,7 +7,6 @@ jobs:
   build-and-test-api:
     runs-on: ubuntu-latest
     env:
-      LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
       AWS_REGION: eu-west-2
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ At the prompts configure the `code-artifact` profile as follows:
 Note: AWS CLI must be installed on the developer workstation as a pre-requisite.
 
 #### Running Tests
-In order to run the tests successfully, you will first need to set the `LOCALSTACK_API_KEY` environment variable (i.e.
-within your .bash_profile or similar). Then run:
+
 ```
 $ ./gradlew check
 ```


### PR DESCRIPTION
This codebase doesn't use localstack pro, so the API key is not required.

I'll also remove the API key from the repo secrets after this is merged