### PR TITLE
EIP1-12975 - update stats message yaml to match print and apps APIs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -169,9 +169,9 @@ tasks.create("generate-models-from-openapi-document-NotificationsAPIs.yaml", Gen
     configOptions.put("documentationProvider", "none")
 }
 
-tasks.create("generate-models-from-openapi-document-UpdateStatisticsMessage.yaml", GenerateTask::class) {
+tasks.create("generate-models-from-openapi-document-shared-stats-update-sqs-messaging.yaml", GenerateTask::class) {
     enabled = true
-    inputSpec.set("$projectDir/src/main/resources/openapi/sqs/applications-api/UpdateStatisticsMessage.yaml")
+    inputSpec.set("$projectDir/src/main/resources/openapi/sqs/applications-api/shared-stats-update-sqs-messaging.yaml")
     packageName.set("uk.gov.dluhc.applicationsapi.messaging")
 }
 

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/config/MessagingConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/config/MessagingConfiguration.kt
@@ -9,9 +9,9 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
 import org.springframework.context.annotation.Profile
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import uk.gov.dluhc.applicationsapi.messaging.models.UpdateApplicationStatisticsMessage
 import uk.gov.dluhc.messagingsupport.MessageQueue
 import uk.gov.dluhc.messagingsupport.MessagingConfigurationHelper
-import uk.gov.dluhc.applicationsapi.messaging.models.UpdateStatisticsMessage as ApplicationUpdateStatisticsMessage
 
 @Configuration
 class MessagingConfiguration {
@@ -29,7 +29,7 @@ class MessagingConfiguration {
 
     @Bean
     fun triggerApplicationStatisticsUpdateQueue(sqsTemplate: SqsTemplate) =
-        MessageQueue<ApplicationUpdateStatisticsMessage>(triggerApplicationStatisticsUpdateQueueName, sqsTemplate)
+        MessageQueue<UpdateApplicationStatisticsMessage>(triggerApplicationStatisticsUpdateQueueName, sqsTemplate)
 
     @Bean
     fun sqsMessagingMessageConverter(

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/service/StatisticsUpdateService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/service/StatisticsUpdateService.kt
@@ -1,13 +1,13 @@
 package uk.gov.dluhc.notificationsapi.service
 
 import org.springframework.stereotype.Service
+import uk.gov.dluhc.applicationsapi.messaging.models.UpdateApplicationStatisticsMessage
 import uk.gov.dluhc.messagingsupport.MessageQueue
 import java.util.UUID
-import uk.gov.dluhc.applicationsapi.messaging.models.UpdateStatisticsMessage as ApplicationUpdateStatisticsMessage
 
 @Service
 class StatisticsUpdateService(
-    private val triggerApplicationStatisticsUpdateQueue: MessageQueue<ApplicationUpdateStatisticsMessage>,
+    private val triggerApplicationStatisticsUpdateQueue: MessageQueue<UpdateApplicationStatisticsMessage>,
 ) {
     fun triggerStatisticsUpdate(applicationId: String) {
         val deduplicationId = UUID.randomUUID().toString()
@@ -15,7 +15,7 @@ class StatisticsUpdateService(
     }
 
     fun submitToTriggerApplicationStatisticsUpdateQueue(applicationId: String, deduplicationId: String) {
-        val updateMessage = ApplicationUpdateStatisticsMessage(applicationId = applicationId)
+        val updateMessage = UpdateApplicationStatisticsMessage(externalId = applicationId)
         triggerApplicationStatisticsUpdateQueue.submit(updateMessage, createMap(applicationId, deduplicationId))
     }
 

--- a/src/main/resources/openapi/sqs/applications-api/shared-stats-update-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/applications-api/shared-stats-update-sqs-messaging.yaml
@@ -1,11 +1,14 @@
 openapi: 3.0.0
 info:
-  title: Application API SQS Message Types for EROP Clients
-  version: '1.0.0'
+  title: Applications API SQS Message Types for stats update
+  version: '0.0.0'
   description: |-
-    Application API SQS Message Types for EROP Clients
+    Applications API SQS Message Types for stats update
     
-    Messages defined in this spec are produced by EROP and consumed by the applications API
+    Messages defined in this spec are produced by the Applications API, notifications API and the Print API.
+    Messages defined in this spec are consumed by the Applications API.
+    
+    Any changes to this spec should be based on joint collaboration and agreement between the Applications APIs and the Print API.
     
     Whilst this is an openAPI spec, it does not imply being used to define REST APIs, nor is it intended to.
     
@@ -29,7 +32,7 @@ paths:
       tags:
         - SQS Queues
       requestBody:
-        $ref: '#/components/requestBodies/UpdateStatisticsMessage'
+        $ref: '#/components/requestBodies/UpdateApplicationStatisticsMessage'
       responses:
         '204':
           description: No response content.
@@ -38,23 +41,29 @@ components:
   # Schema and Enum Definitions
   # --------------------------------------------------------------------------------
   schemas:
-    UpdateStatisticsMessage:
-      title: UpdateStatisticsMessage
+    UpdateApplicationStatisticsMessage:
+      title: TriggerApplicationStatisticsUpdateMessage
       type: object
-      description: SQS Message for initiating a statistics update for an application.
+      description: SQS message for initiating a statistics update for an application
       properties:
-        applicationId:
+        externalId:
           type: string
-          description: The identifier of the application
+          description: The identifier of the Application
           example: 1f0f76a9a66f438b9bb33070
       required:
-        - applicationId
+        - externalId
+
+  #
+  # Response Body Definitions
+  # --------------------------------------------------------------------------------
+  responses: { }
+
+  #
+  # Request Body Definitions
+  # --------------------------------------------------------------------------------
   requestBodies:
-    #
-    # Request Body Definitions
-    # --------------------------------------------------------------------------------
-    UpdateStatisticsMessage:
+    UpdateApplicationStatisticsMessage:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/UpdateStatisticsMessage'
+            $ref: '#/components/schemas/UpdateApplicationStatisticsMessage'

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/config/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/config/IntegrationTest.kt
@@ -190,7 +190,7 @@ internal abstract class IntegrationTest {
         val messages = updateApplicationStatisticsMessageListenerStub.getMessages()
         Assertions.assertThat(messages).isNotEmpty
         Assertions.assertThat(messages).anyMatch {
-            it.applicationId == applicationId
+            it.externalId == applicationId
         }
     }
 

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/service/StatisticsUpdateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/service/StatisticsUpdateServiceTest.kt
@@ -16,10 +16,10 @@ import org.mockito.kotlin.capture
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
+import uk.gov.dluhc.applicationsapi.messaging.models.UpdateApplicationStatisticsMessage
 import uk.gov.dluhc.messagingsupport.MessageQueue
 import uk.gov.dluhc.notificationsapi.dto.SourceType
 import uk.gov.dluhc.notificationsapi.testsupport.testdata.aRandomSourceReference
-import uk.gov.dluhc.applicationsapi.messaging.models.UpdateStatisticsMessage as ApplicationUpdateStatisticsMessage
 
 @ExtendWith(MockitoExtension::class)
 class StatisticsUpdateServiceTest {
@@ -31,7 +31,7 @@ class StatisticsUpdateServiceTest {
     private lateinit var headersArgumentCaptor: ArgumentCaptor<Map<String, Any>>
 
     @Mock
-    private lateinit var triggerApplicationStatisticsUpdateQueue: MessageQueue<ApplicationUpdateStatisticsMessage>
+    private lateinit var triggerApplicationStatisticsUpdateQueue: MessageQueue<UpdateApplicationStatisticsMessage>
 
     @BeforeEach
     fun setUp() {
@@ -51,7 +51,7 @@ class StatisticsUpdateServiceTest {
 
         // Then
         verify(triggerApplicationStatisticsUpdateQueue).submit(
-            eq(ApplicationUpdateStatisticsMessage(applicationId)),
+            eq(UpdateApplicationStatisticsMessage(applicationId)),
             any(),
         )
         verifyNoMoreInteractions(triggerApplicationStatisticsUpdateQueue)

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/stubs/UpdateApplicationStatisticsMessageListenerStub.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/stubs/UpdateApplicationStatisticsMessageListenerStub.kt
@@ -4,15 +4,15 @@ import io.awspring.cloud.sqs.annotation.SqsListener
 import jakarta.validation.Valid
 import org.springframework.messaging.handler.annotation.Payload
 import org.springframework.stereotype.Component
-import uk.gov.dluhc.applicationsapi.messaging.models.UpdateStatisticsMessage
+import uk.gov.dluhc.applicationsapi.messaging.models.UpdateApplicationStatisticsMessage
 
 @Component
-class UpdateApplicationStatisticsMessageListenerStub : MessageListenerStub<UpdateStatisticsMessage>() {
+class UpdateApplicationStatisticsMessageListenerStub : MessageListenerStub<UpdateApplicationStatisticsMessage>() {
 
     @SqsListener("\${sqs.trigger-application-statistics-update-queue-name}")
     override fun handleMessage(
         @Valid @Payload
-        payload: UpdateStatisticsMessage,
+        payload: UpdateApplicationStatisticsMessage,
     ) {
         super.handleMessage(payload)
     }


### PR DESCRIPTION
## Describe your changes

update stats update yaml to match print and apps

notifications API was sending a message with applicationId not externalId

## Issue ticket number and link

https://dluhcdigital.atlassian.net/browse/EIP1-12975

## Checklist before requesting a review

- [ ] I double checked that ACs on the ticket are met by this code update
- [ ] I have added testing steps to the ticket
- [ ] I have updated the relevant yml versions
- [ ] I have formatted the code
- [ ] I have added tests to new code and updated existing tests where needed
- [ ] I have added any corresponding changes to the API services

## Additional notes
