### PR TITLE
EIP1-12986: Fix flaky SQS tests

### DIFF
--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/config/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/config/IntegrationTest.kt
@@ -206,25 +206,25 @@ internal abstract class IntegrationTest {
     fun clearSqsQueues() {
         with(localStackContainerSettings) {
             CompletableFuture.allOf(
-                clearSqsQueue(mappedQueueUrlSendUkGovNotifyPhotoResubmissionQueueName),
-                clearSqsQueue(mappedQueueUrlSendUkGovNotifyIdDocumentResubmissionQueueName),
-                clearSqsQueue(mappedQueueUrlSendUkGovNotifyIdDocumentRequiredQueueName),
-                clearSqsQueue(mappedQueueUrlSendUkGovNotifyApplicationReceivedQueueName),
-                clearSqsQueue(mappedQueueUrlSendUkGovNotifyApplicationApprovedQueueName),
-                clearSqsQueue(mappedQueueUrlSendUkGovNotifyApplicationRejectedMessageQueueName),
-                clearSqsQueue(mappedQueueUrlSendUkGovNotifyRejectedDocumentMessageQueueName),
-                clearSqsQueue(mappedQueueUrlRemoveApplicationNotificationsQueueName),
-                clearSqsQueue(mappedQueueUrlSendUkGovNotifyNinoNotMatchedMessageQueueName),
-                clearSqsQueue(mappedQueueUrlSendUkGovNotifyBespokeCommMessageQueueName),
-                clearSqsQueue(mappedQueueUrlSendUkGovNotifyNotRegisteredToVoteMessageQueueName),
-                clearSqsQueue(mappedQueueUrlSendUkGovNotifyRequestedSignatureQueueName),
-                clearSqsQueue(mappedQueueUrlSendUkGovNotifyRejectedSignatureQueueName),
-                clearSqsQueue(sendUkGovNotifyRequestedSignatureQueueName),
-                clearSqsQueue(sendUkGovNotifyRejectedSignatureQueueName),
+                clearSqsQueueAsync(mappedQueueUrlSendUkGovNotifyPhotoResubmissionQueueName),
+                clearSqsQueueAsync(mappedQueueUrlSendUkGovNotifyIdDocumentResubmissionQueueName),
+                clearSqsQueueAsync(mappedQueueUrlSendUkGovNotifyIdDocumentRequiredQueueName),
+                clearSqsQueueAsync(mappedQueueUrlSendUkGovNotifyApplicationReceivedQueueName),
+                clearSqsQueueAsync(mappedQueueUrlSendUkGovNotifyApplicationApprovedQueueName),
+                clearSqsQueueAsync(mappedQueueUrlSendUkGovNotifyApplicationRejectedMessageQueueName),
+                clearSqsQueueAsync(mappedQueueUrlSendUkGovNotifyRejectedDocumentMessageQueueName),
+                clearSqsQueueAsync(mappedQueueUrlRemoveApplicationNotificationsQueueName),
+                clearSqsQueueAsync(mappedQueueUrlSendUkGovNotifyNinoNotMatchedMessageQueueName),
+                clearSqsQueueAsync(mappedQueueUrlSendUkGovNotifyBespokeCommMessageQueueName),
+                clearSqsQueueAsync(mappedQueueUrlSendUkGovNotifyNotRegisteredToVoteMessageQueueName),
+                clearSqsQueueAsync(mappedQueueUrlSendUkGovNotifyRequestedSignatureQueueName),
+                clearSqsQueueAsync(mappedQueueUrlSendUkGovNotifyRejectedSignatureQueueName),
+                clearSqsQueueAsync(sendUkGovNotifyRequestedSignatureQueueName),
+                clearSqsQueueAsync(sendUkGovNotifyRejectedSignatureQueueName),
             ).join()
         }
     }
 
-    fun clearSqsQueue(queueUrl: String): CompletableFuture<PurgeQueueResponse> =
+    fun clearSqsQueueAsync(queueUrl: String): CompletableFuture<PurgeQueueResponse> =
         amazonSQSAsync.purgeQueue(PurgeQueueRequest.builder().queueUrl(queueUrl).build())
 }

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyApplicationApprovedMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyApplicationApprovedMessageListenerIntegrationTest.kt
@@ -4,6 +4,7 @@ import mu.KotlinLogging
 import org.apache.commons.lang3.time.StopWatch
 import org.assertj.core.api.Assertions
 import org.awaitility.kotlin.await
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import uk.gov.dluhc.notificationsapi.config.IntegrationTest
@@ -18,6 +19,11 @@ import java.util.concurrent.TimeUnit
 private val logger = KotlinLogging.logger {}
 
 internal class SendNotifyApplicationApprovedMessageListenerIntegrationTest : IntegrationTest() {
+
+    @BeforeEach
+    fun cleanUp() {
+        clearSqsQueueAsync(sendUkGovNotifyApplicationApprovedQueueName).join()
+    }
 
     @ParameterizedTest
     @EnumSource(Language::class)

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyApplicationReceivedMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyApplicationReceivedMessageListenerIntegrationTest.kt
@@ -4,6 +4,7 @@ import mu.KotlinLogging
 import org.apache.commons.lang3.time.StopWatch
 import org.assertj.core.api.Assertions
 import org.awaitility.kotlin.await
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import uk.gov.dluhc.notificationsapi.config.IntegrationTest
@@ -19,6 +20,11 @@ import uk.gov.dluhc.notificationsapi.database.entity.SourceType as SourceTypeEnt
 private val logger = KotlinLogging.logger {}
 
 internal class SendNotifyApplicationReceivedMessageListenerIntegrationTest : IntegrationTest() {
+
+    @BeforeEach
+    fun cleanUp() {
+        clearSqsQueueAsync(sendUkGovNotifyApplicationReceivedQueueName).join()
+    }
 
     @ParameterizedTest
     @CsvSource(

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyApplicationRejectedMessageIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyApplicationRejectedMessageIntegrationTest.kt
@@ -2,6 +2,7 @@ package uk.gov.dluhc.notificationsapi.messaging
 
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import uk.gov.dluhc.notificationsapi.config.IntegrationTest
@@ -27,6 +28,12 @@ import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 internal class SendNotifyApplicationRejectedMessageIntegrationTest : IntegrationTest() {
+
+    @BeforeEach
+    fun cleanUp() {
+        clearSqsQueueAsync(sendUkGovNotifyApplicationRejectedQueueName).join()
+    }
+
     @ParameterizedTest
     @CsvSource(
         value = [

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyBespokeCommMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyBespokeCommMessageListenerIntegrationTest.kt
@@ -4,7 +4,6 @@ import mu.KotlinLogging
 import org.apache.commons.lang3.time.StopWatch
 import org.assertj.core.api.Assertions
 import org.awaitility.kotlin.await
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
@@ -26,9 +25,8 @@ private val logger = KotlinLogging.logger {}
 internal class SendNotifyBespokeCommMessageListenerIntegrationTest : IntegrationTest() {
 
     @BeforeEach
-    @AfterEach
     fun cleanUp() {
-        clearSqsQueue(sendUkGovNotifyBespokeCommQueueName)
+        clearSqsQueueAsync(sendUkGovNotifyBespokeCommQueueName).join()
     }
 
     @ParameterizedTest

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyIdDocumentRequiredMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyIdDocumentRequiredMessageListenerIntegrationTest.kt
@@ -4,6 +4,7 @@ import mu.KotlinLogging
 import org.apache.commons.lang3.time.StopWatch
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import uk.gov.dluhc.notificationsapi.config.IntegrationTest
@@ -24,6 +25,11 @@ import java.util.concurrent.TimeUnit
 private val logger = KotlinLogging.logger {}
 
 internal class SendNotifyIdDocumentRequiredMessageListenerIntegrationTest : IntegrationTest() {
+
+    @BeforeEach
+    fun cleanUp() {
+        clearSqsQueueAsync(sendUkGovNotifyIdDocumentRequiredQueueName).join()
+    }
 
     @ParameterizedTest
     @EnumSource(Language::class)

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyIdDocumentResubmissionMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyIdDocumentResubmissionMessageListenerIntegrationTest.kt
@@ -4,6 +4,7 @@ import mu.KotlinLogging
 import org.apache.commons.lang3.time.StopWatch
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import uk.gov.dluhc.notificationsapi.config.IntegrationTest
@@ -24,6 +25,11 @@ import java.util.concurrent.TimeUnit
 private val logger = KotlinLogging.logger {}
 
 internal class SendNotifyIdDocumentResubmissionMessageListenerIntegrationTest : IntegrationTest() {
+
+    @BeforeEach
+    fun cleanUp() {
+        clearSqsQueueAsync(sendUkGovNotifyIdDocumentResubmissionQueueName).join()
+    }
 
     @ParameterizedTest
     @EnumSource(Language::class)

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyNinoNotMatchedMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyNinoNotMatchedMessageListenerIntegrationTest.kt
@@ -4,6 +4,7 @@ import mu.KotlinLogging
 import org.apache.commons.lang3.time.StopWatch
 import org.assertj.core.api.Assertions
 import org.awaitility.kotlin.await
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import uk.gov.dluhc.notificationsapi.config.IntegrationTest
@@ -24,6 +25,11 @@ import uk.gov.dluhc.notificationsapi.database.entity.SourceType as SourceTypeEnt
 private val logger = KotlinLogging.logger {}
 
 internal class SendNotifyNinoNotMatchedMessageListenerIntegrationTest : IntegrationTest() {
+
+    @BeforeEach
+    fun cleanUp() {
+        clearSqsQueueAsync(sendUkGovNotifyNinoNotMatchedQueueName).join()
+    }
 
     companion object {
         private const val SOURCE_TYPE_POSTAL = "POSTAL"

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyNotRegisteredToVoteMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyNotRegisteredToVoteMessageListenerIntegrationTest.kt
@@ -4,7 +4,7 @@ import mu.KotlinLogging
 import org.apache.commons.lang3.time.StopWatch
 import org.assertj.core.api.Assertions
 import org.awaitility.kotlin.await
-import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import uk.gov.dluhc.notificationsapi.config.IntegrationTest
@@ -24,9 +24,9 @@ private val logger = KotlinLogging.logger {}
 
 internal class SendNotifyNotRegisteredToVoteMessageListenerIntegrationTest : IntegrationTest() {
 
-    @AfterEach
+    @BeforeEach
     fun cleanUp() {
-        clearSqsQueue(sendUkGovNotifyNotRegisteredToVoteQueueName)
+        clearSqsQueueAsync(sendUkGovNotifyNotRegisteredToVoteQueueName).join()
     }
 
     @ParameterizedTest

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyPhotoResubmissionMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyPhotoResubmissionMessageListenerIntegrationTest.kt
@@ -4,6 +4,7 @@ import mu.KotlinLogging
 import org.apache.commons.lang3.time.StopWatch
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import uk.gov.dluhc.notificationsapi.config.IntegrationTest
@@ -21,6 +22,11 @@ import java.util.concurrent.TimeUnit
 private val logger = KotlinLogging.logger {}
 
 internal class SendNotifyPhotoResubmissionMessageListenerIntegrationTest : IntegrationTest() {
+
+    @BeforeEach
+    fun cleanUp() {
+        clearSqsQueueAsync(sendUkGovNotifyPhotoResubmissionQueueName).join()
+    }
 
     @ParameterizedTest
     @EnumSource(Language::class)

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyRejectedDocumentMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyRejectedDocumentMessageListenerIntegrationTest.kt
@@ -4,6 +4,7 @@ import mu.KotlinLogging
 import org.apache.commons.lang3.time.StopWatch
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import uk.gov.dluhc.notificationsapi.config.IntegrationTest
@@ -24,6 +25,11 @@ import uk.gov.dluhc.notificationsapi.database.entity.SourceType as SourceTypeEnt
 private val logger = KotlinLogging.logger {}
 
 internal class SendNotifyRejectedDocumentMessageListenerIntegrationTest : IntegrationTest() {
+
+    @BeforeEach
+    fun cleanUp() {
+        clearSqsQueueAsync(sendUkGovNotifyRejectedDocumentQueueName).join()
+    }
 
     companion object {
         private const val SOURCE_TYPE_POSTAL = "POSTAL"

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyRejectedSignatureMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyRejectedSignatureMessageListenerIntegrationTest.kt
@@ -4,7 +4,6 @@ import mu.KotlinLogging
 import org.apache.commons.lang3.time.StopWatch
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
@@ -26,9 +25,8 @@ private val logger = KotlinLogging.logger {}
 internal class SendNotifyRejectedSignatureMessageListenerIntegrationTest : IntegrationTest() {
 
     @BeforeEach
-    @AfterEach
     fun cleanUp() {
-        clearSqsQueue(sendUkGovNotifyRejectedSignatureQueueName)
+        clearSqsQueueAsync(sendUkGovNotifyRejectedSignatureQueueName).join()
     }
 
     @ParameterizedTest

--- a/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyRequestedSignatureMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/notificationsapi/messaging/SendNotifyRequestedSignatureMessageListenerIntegrationTest.kt
@@ -4,7 +4,6 @@ import mu.KotlinLogging
 import org.apache.commons.lang3.time.StopWatch
 import org.assertj.core.api.Assertions
 import org.awaitility.kotlin.await
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
@@ -26,9 +25,8 @@ private val logger = KotlinLogging.logger {}
 internal class SendNotifyRequestedSignatureMessageListenerIntegrationTest : IntegrationTest() {
 
     @BeforeEach
-    @AfterEach
     fun cleanUp() {
-        clearSqsQueue(sendUkGovNotifyRequestedSignatureQueueName)
+        clearSqsQueueAsync(sendUkGovNotifyRequestedSignatureQueueName).join()
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## Describe your changes

Fix flaky SQS tests which result in multiple pipeline reruns before PRs can be merged etc.
Tests either:
- did not include any cleanup step
- was cleaning up both `@BeforeEach` and `@AfterEach`
- were not waiting for response from `clearSqsQueues()` step
Tests now:
- always include cleanup
- cleanup `@BeforeEach` to allow for easier debugging in future
- include `.join()` after the clearing of queues
Also, `clearSqsQueues()` has now been renamed `clearSqsQueuesAsync()` to make clear this is an async function which should return.

## Issue ticket number and link

https://dluhcdigital.atlassian.net/browse/EIP1-12986

## Checklist before requesting a review

- [x] I double checked that ACs on the ticket are met by this code update
- [ ] I have added testing steps to the ticket
- [ ] I have updated the relevant yml versions
- [x] I have formatted the code
- [ ] I have added tests to new code and updated existing tests where needed
- [ ] I have added any corresponding changes to the API services

## Additional notes
