### PR TITLE
EIP1-13868: Add to-do checker shared workflow

### DIFF
--- a/.github/workflows/todo-check-with-slack-notify.yml
+++ b/.github/workflows/todo-check-with-slack-notify.yml
@@ -1,0 +1,12 @@
+name: Run todo checker
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  check-todos:
+    uses: communitiesuk/eip-ero-shared-workflows/.github/workflows/todo-check-with-slack-notify.yml@main
+    with:
+      exclude-path-regex: (\.github\/workflows\/todo-check-with-slack-notify\.yml)
+    secrets: inherit

--- a/.github/workflows/todo-check-with-slack-notify.yml
+++ b/.github/workflows/todo-check-with-slack-notify.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - EIP1-13868-set-up-to-do-checker
 
 jobs:
   check-todos:

--- a/.github/workflows/todo-check-with-slack-notify.yml
+++ b/.github/workflows/todo-check-with-slack-notify.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - EIP1-13868-set-up-to-do-checker
 
 jobs:
   check-todos:

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/NotificationsApiApplication.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/NotificationsApiApplication.kt
@@ -4,8 +4,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 
-// TODO EIP1-13474: Test todo checker with old todo that is done
-
 /**
  * Spring Boot application bootstrapping class.
  */

--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/NotificationsApiApplication.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/NotificationsApiApplication.kt
@@ -4,6 +4,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 
+// TODO EIP1-13474: Test todo checker with old todo that is done
+
 /**
  * Spring Boot application bootstrapping class.
  */


### PR DESCRIPTION
## Describe your changes
Add the shared to-do check workflow to notifications.
I have also added JIRA_USER, JIRA_PASSWORD and SLACK_TODO_CHECKER_ALERTS_WEBHOOK to the repo secrets as outlined [here](https://github.com/communitiesuk/eip-ero-shared-workflows/tree/main).

Tested by adding a TODO for a closed ticket and saw the slack notification as expected:
<img width="2018" height="230" alt="image" src="https://github.com/user-attachments/assets/4aad3899-a0b2-45d5-80f0-03599151c102" />


## Issue ticket number and link

https://dluhcdigital.atlassian.net/browse/EIP1-13710

## Checklist before requesting a review
Tick all those which are done
Replace check box with ❌ if the step is not relevant for this PR

- [x] I double checked that ACs on the ticket are met by this code update
-  ❌ I have checked any risky steps with my TL ([cheat sheet for safe release here](https://mhclgdigital.atlassian.net/wiki/spaces/ED1/pages/871694357/Safe+Release+Cheat+Sheet))
-  ❌ I have updated the relevant yml versions
- ❌ I have added tests to new code and updated existing tests where needed
-  ❌ I have added any corresponding changes to the API services
-  ❌ I have considered if any communication statistics changes are necessary ([documentation here](../docs/statistics.md))
-  ❌ I have documented any release dependencies (e.g. service release order or incompatible versions) in the [Release notes](https://mhclgdigital.atlassian.net/wiki/spaces/ED1/pages/873365661/Release+-+EROP+Version+-+Date+TBC)
    - Can leave tags as tbd until merged
