### PR TITLE
EROPSPT-603: Disable FAIL_ON_NULL_FOR_PRIMITIVES

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/notificationsapi/config/JacksonConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/notificationsapi/config/JacksonConfiguration.kt
@@ -18,6 +18,7 @@ class JacksonConfiguration {
             .addModule(KotlinModule.Builder().build())
             .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
             .disable(DateTimeFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+            .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
             .changeDefaultPropertyInclusion { _ -> JsonInclude.Value.construct(Include.NON_NULL, Include.NON_NULL) }
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
             .build()


### PR DESCRIPTION
## Describe your changes

Jackson upgrade to v3 set default for FAIL_ON_NULL_FOR_PRIMITIVES flag to true - reverting this change by manually disabling this.

## Issue ticket number and link

https://mhclgdigital.atlassian.net/browse/EROPSPT-603

## Checklist before requesting a review
Tick all those which are done
Replace check box with ❌ if the step is not relevant for this PR

- [ ] I double checked that ACs on the ticket are met by this code update
- [ ] I have checked any risky steps with my TL ([cheat sheet for safe release here](https://mhclgdigital.atlassian.net/wiki/spaces/ED1/pages/871694357/Safe+Release+Cheat+Sheet))
- [ ] I have updated the relevant yml versions
- [ ] I have added tests to new code and updated existing tests where needed
- [ ] I have added any corresponding changes to the API services
- [ ] I have considered if any communication statistics changes are necessary ([documentation here](../docs/statistics.md))
- [ ] I have documented any release dependencies (e.g. service release order or incompatible versions) in the [Release notes](https://mhclgdigital.atlassian.net/wiki/spaces/ED1/pages/873365661/Release+-+EROP+Version+-+Date+TBC)
    - Can leave tags as tbd until merged
